### PR TITLE
Allow per-dataset sampling configs

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -46,11 +46,12 @@ type InMemCollector struct {
 	Config       config.Config         `inject:""`
 	Logger       logger.Logger         `inject:""`
 	Transmission transmit.Transmission `inject:""`
-	Sampler      sample.Sampler        `inject:""`
 	Metrics      metrics.Metrics       `inject:""`
 
-	cacheLock sync.Mutex
-	Cache     cache.Cache
+	cacheLock       sync.Mutex
+	Cache           cache.Cache
+	datasetSamplers map[string]sample.Sampler
+	defaultSampler  sample.Sampler
 }
 
 type imcConfig struct {
@@ -58,6 +59,7 @@ type imcConfig struct {
 }
 
 func (i *InMemCollector) Start() error {
+	i.defaultSampler = sample.GetDefaultSamplerImplementation(i.Config)
 	imcConfig := &imcConfig{}
 	err := i.Config.GetOtherConfig("InMemCollector", imcConfig)
 	if err != nil {
@@ -230,8 +232,26 @@ func (i *InMemCollector) send(trace *types.Trace) {
 	// hey, we're sending the trace! we should cancel the timeout goroutine.
 	defer trace.CancelSending()
 
+	var sampler sample.Sampler
+	var found bool
+
+	if sampler, found = i.datasetSamplers[trace.Dataset]; !found {
+		sampler = sample.GetSamplerImplementationForDataset(i.Config, trace.Dataset)
+		// no dataset sampler found, use default sampler
+		if sampler == nil {
+			sampler = i.defaultSampler
+		}
+
+		if i.datasetSamplers == nil {
+			i.datasetSamplers = make(map[string]sample.Sampler)
+		}
+
+		// save sampler for later
+		i.datasetSamplers[trace.Dataset] = sampler
+	}
+
 	// make sampling decision and update the trace
-	rate, shouldSend := i.Sampler.GetSampleRate(trace)
+	rate, shouldSend := sampler.GetSampleRate(trace)
 	trace.SampleRate = rate
 	trace.KeepSample = shouldSend
 	trace.Sent = true

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -20,16 +20,21 @@ import (
 func TestAddRootSpan(t *testing.T) {
 	transmission := &transmit.MockTransmission{}
 	transmission.Start()
+	conf := &config.MockConfig{
+		GetSendDelayVal:          0,
+		GetTraceTimeoutVal:       60,
+		GetDefaultSamplerTypeVal: "DeterministicSampler",
+	}
 	coll := &InMemCollector{
-		Config: &config.MockConfig{
-			GetSendDelayVal:          0,
-			GetTraceTimeoutVal:       60,
-			GetDefaultSamplerTypeVal: "DeterministicSampler",
-		},
+		Config:         conf,
 		Logger:         &logger.NullLogger{},
 		Transmission:   transmission,
 		defaultSampler: &sample.DeterministicSampler{},
 		Metrics:        &metrics.NullMetrics{},
+		SamplerFactory: &sample.SamplerFactory{
+			Config: conf,
+			Logger: &logger.NullLogger{},
+		},
 	}
 	c := &cache.DefaultInMemCache{
 		Config: cache.CacheConfig{
@@ -63,16 +68,21 @@ func TestAddRootSpan(t *testing.T) {
 func TestAddSpan(t *testing.T) {
 	transmission := &transmit.MockTransmission{}
 	transmission.Start()
+	conf := &config.MockConfig{
+		GetSendDelayVal:          0,
+		GetTraceTimeoutVal:       60,
+		GetDefaultSamplerTypeVal: "DeterministicSampler",
+	}
 	coll := &InMemCollector{
-		Config: &config.MockConfig{
-			GetSendDelayVal:          0,
-			GetTraceTimeoutVal:       60,
-			GetDefaultSamplerTypeVal: "DeterministicSampler",
-		},
+		Config:         conf,
 		Logger:         &logger.NullLogger{},
 		Transmission:   transmission,
 		defaultSampler: &sample.DeterministicSampler{},
 		Metrics:        &metrics.NullMetrics{},
+		SamplerFactory: &sample.SamplerFactory{
+			Config: conf,
+			Logger: &logger.NullLogger{},
+		},
 	}
 	c := &cache.DefaultInMemCache{
 		Config: cache.CacheConfig{

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -22,13 +22,14 @@ func TestAddRootSpan(t *testing.T) {
 	transmission.Start()
 	coll := &InMemCollector{
 		Config: &config.MockConfig{
-			GetSendDelayVal:    0,
-			GetTraceTimeoutVal: 60,
+			GetSendDelayVal:          0,
+			GetTraceTimeoutVal:       60,
+			GetDefaultSamplerTypeVal: "DeterministicSampler",
 		},
-		Logger:       &logger.NullLogger{},
-		Transmission: transmission,
-		Sampler:      &sample.DeterministicSampler{},
-		Metrics:      &metrics.NullMetrics{},
+		Logger:         &logger.NullLogger{},
+		Transmission:   transmission,
+		defaultSampler: &sample.DeterministicSampler{},
+		Metrics:        &metrics.NullMetrics{},
 	}
 	c := &cache.DefaultInMemCache{
 		Config: cache.CacheConfig{
@@ -64,13 +65,14 @@ func TestAddSpan(t *testing.T) {
 	transmission.Start()
 	coll := &InMemCollector{
 		Config: &config.MockConfig{
-			GetSendDelayVal:    0,
-			GetTraceTimeoutVal: 60,
+			GetSendDelayVal:          0,
+			GetTraceTimeoutVal:       60,
+			GetDefaultSamplerTypeVal: "DeterministicSampler",
 		},
-		Logger:       &logger.NullLogger{},
-		Transmission: transmission,
-		Sampler:      &sample.DeterministicSampler{},
-		Metrics:      &metrics.NullMetrics{},
+		Logger:         &logger.NullLogger{},
+		Transmission:   transmission,
+		defaultSampler: &sample.DeterministicSampler{},
+		Metrics:        &metrics.NullMetrics{},
 	}
 	c := &cache.DefaultInMemCache{
 		Config: cache.CacheConfig{

--- a/config.toml
+++ b/config.toml
@@ -120,83 +120,83 @@ Metrics = "honeycomb"
 # temporary odd sampling decisions).
 CacheCapacity = 1000
 
+[[SamplerConfig]]
 
-###########################
-## Deterministic Sampler ##
-###########################
+	[SamplerConfig._default]
 
-# DeterministicSampler is a section of the config for manipulating the
-# Deterministic Sampler implementation. This is the simplest sampling algorithm
-# - it is a static sample rate, choosing traces randomly to either keep or send
-# (at the appropriate rate). It is not influenced by the contents of the trace.
-[DeterministicSampler]
+		# DeterministicSampler is a section of the config for manipulating the
+		# Deterministic Sampler implementation. This is the simplest sampling algorithm
+		# - it is a static sample rate, choosing traces randomly to either keep or send
+		# (at the appropriate rate). It is not influenced by the contents of the trace.
+		Sampler = "DeterministicSampler"
 
-# SampleRate is the rate at which to sample. It indicates a ratio, where one
-# sample trace is kept for every n traces seen. For example, a SampleRate of 30
-# will keep 1 out of every 30 traces. The choice on whether to keep any specific
-# trace is random, so the rate is approximate.
-# Eligible for live reload.
-SampleRate = 2
+		# SampleRate is the rate at which to sample. It indicates a ratio, where one
+		# sample trace is kept for every n traces seen. For example, a SampleRate of 30
+		# will keep 1 out of every 30 traces. The choice on whether to keep any specific
+		# trace is random, so the rate is approximate.
+		# Eligible for live reload.
+		SampleRate = 2
 
+	[SamplerConfig.dataset1]
 
-###########################
-## Dynamic Sampler ##
-###########################
+		# DynamicSampler is a section of the config for manipulating the Dynamic Sampler
+		# implementation. This sampler collects the values of a number of fields from a
+		# trace and uses them to form a key. This key is handed to the standard dynamic
+		# sampler algorithm which generates a sample rate based on the frequency with
+		# which that key has appeared in the previous 30 seconds. See
+		# https://github.com/honeycombio/dynsampler-go for more detail on the mechanics
+		# of the dynamic sampler.  This sampler uses the AvgSampleRate algorithm from
+		# that package.
+		Sampler = "DynamicSampler"
 
-# DynamicSampler is a section of the config for manipulating the Dynamic Sampler
-# implementation. This sampler collects the values of a number of fields from a
-# trace and uses them to form a key. This key is handed to the standard dynamic
-# sampler algorithm which generates a sample rate based on the frequency with
-# which that key has appeared in the previous 30 seconds. See
-# https://github.com/honeycombio/dynsampler-go for more detail on the mechanics
-# of the dynamic sampler.  This sampler uses the AvgSampleRate algorithm from
-# that package.
-[DynamicSampler]
+		# SampleRate is the goal rate at which to sample. It indicates a ratio, where
+		# one sample trace is kept for every n traces seen. For example, a SampleRate of
+		# 30 will keep 1 out of every 30 traces. This rate is handed to the dynamic
+		# sampler, who assigns a sample rate for each trace based on the fields selected
+		# from that trace.
+		# Eligible for live reload.
+		SampleRate = 2
 
-# SampleRate is the goal rate at which to sample. It indicates a ratio, where
-# one sample trace is kept for every n traces seen. For example, a SampleRate of
-# 30 will keep 1 out of every 30 traces. This rate is handed to the dynamic
-# sampler, who assigns a sample rate for each trace based on the fields selected
-# from that trace.
-# Eligible for live reload.
-SampleRate = 2
+		# FieldList is a list of all the field names to use to form the key that will be
+		# handed to the dynamic sampler. The cardinality of the combination of values
+		# from all of these keys should be reasonable in the face of the frequency of
+		# those keys. If the combination of fields in these keys essentially makes them
+		# unique, the dynamic sampler will do no sampling.  If the keys have too few
+		# values, you won't get samples of the most interesting traces. A good key
+		# selection will have consistent values for high frequency boring traffic and
+		# unique values for outliers and interesting traffic. Including an error field
+		# (or something like HTTP status code) is an excellent choice. As an example,
+		# assuming 30 or so endpoints, a combination of HTTP endpoint and status code
+		# would be a good set of keys in order to let you see accurately use of all
+		# endpoints and call out when there is failing traffic to any endpoint. Field
+		# names may come from any span in the trace.
+		# Eligible for live reload.
+		FieldList = ["request.method","response.status_code"]
 
-# FieldList is a list of all the field names to use to form the key that will be
-# handed to the dynamic sampler. The cardinality of the combination of values
-# from all of these keys should be reasonable in the face of the frequency of
-# those keys. If the combination of fields in these keys essentially makes them
-# unique, the dynamic sampler will do no sampling.  If the keys have too few
-# values, you won't get samples of the most interesting traces. A good key
-# selection will have consistent values for high frequency boring traffic and
-# unique values for outliers and interesting traffic. Including an error field
-# (or something like HTTP status code) is an excellent choice. As an example,
-# assuming 30 or so endpoints, a combination of HTTP endpoint and status code
-# would be a good set of keys in order to let you see accurately use of all
-# endpoints and call out when there is failing traffic to any endpoint. Field
-# names may come from any span in the trace.
-# Eligible for live reload.
-FieldList = ["request.method","response.status_code"]
+		# UseTraceLength will add the number of spans in the trace in to the dynamic
+		# sampler as part of the key. The number of spans is exact, so if there are
+		# normally small variations in trace length you may want to leave this off. If
+		# traces are consistent lengths and changes in trace length is a useful
+		# indicator of traces you'd like to see in Honeycomb, set this to true.
+		# Eligible for live reload.
+		UseTraceLength = true
 
-# UseTraceLength will add the number of spans in the trace in to the dynamic
-# sampler as part of the key. The number of spans is exact, so if there are
-# normally small variations in trace length you may want to leave this off. If
-# traces are consistent lengths and changes in trace length is a useful
-# indicator of traces you'd like to see in Honeycomb, set this to true.
-# Eligible for live reload.
-UseTraceLength = true
+		# AddSampleRateKeyToTrace when this is set to true, the sampler will add a field
+		# to the root span of the trace containing the key used by the sampler to decide
+		# the sample rate. This can be helpful in understanding why the sampler is
+		# making certain decisions about sample rate and help you understand how to
+		# better choose the sample rate key (aka the FieldList setting above) to use.
+		AddSampleRateKeyToTrace = true
 
-# AddSampleRateKeyToTrace when this is set to true, the sampler will add a field
-# to the root span of the trace containing the key used by the sampler to decide
-# the sample rate. This can be helpful in understanding why the sampler is
-# making certain decisions about sample rate and help you understand how to
-# better choose the sample rate key (aka the FieldList setting above) to use.
-AddSampleRateKeyToTrace = true
+		# AddSampleRateKeyToTraceField is the name of the field the sampler will use
+		# when adding the sample rate key to the trace. This setting is only used when
+		# AddSampleRateKeyToTrace is true.
+		AddSampleRateKeyToTraceField = "meta.samproxy.dynsampler_key"
 
-# AddSampleRateKeyToTraceField is the name of the field the sampler will use
-# when adding the sample rate key to the trace. This setting is only used when
-# AddSampleRateKeyToTrace is true.
-AddSampleRateKeyToTraceField = "meta.samproxy.dynsampler_key"
+	[SamplerConfig.dataset2]
 
+		Sampler = "DeterministicSampler"
+		SampleRate = 10
 
 ###################
 ## Logrus Logger ##

--- a/config/config.go
+++ b/config/config.go
@@ -203,7 +203,7 @@ func (f *FileConfig) GetOtherConfig(name string, iface interface{}) error {
 	if subConfTree, ok := subConf.(*toml.Tree); ok {
 		return subConfTree.Unmarshal(iface)
 	}
-	return fmt.Errorf("failed to find config tree")
+	return fmt.Errorf("failed to find config tree for %s", name)
 }
 
 // MockConfig will respond with whatever config it's set to do during

--- a/config/config.go
+++ b/config/config.go
@@ -61,9 +61,12 @@ type Config interface {
 	// are in the collect package
 	GetCollectorType() (string, error)
 
-	// GetSamplerType returns the type of sampler to use. Valid types are in the
-	// sample package
-	GetSamplerType() (string, error)
+	// GetDefaultSamplerType returns the sampler type to use for all datasets
+	// not explicitly defined
+	GetDefaultSamplerType() (string, error)
+
+	// GetSamplerTypeForDataset returns the sampler type to use for the given dataset
+	GetSamplerTypeForDataset(string) (string, error)
 
 	// GetMetricsType returns the type of metrics to use. Valid types are in the
 	// metrics package
@@ -90,6 +93,12 @@ type confContents struct {
 	Metrics              string
 	SendDelay            int
 	TraceTimeout         int
+}
+
+// Used to marshall in the sampler type in SamplerConfig definitions
+// other fields are ignored
+type samplerConfigType struct {
+	Sampler string
 }
 
 // Start reads the config initially
@@ -159,8 +168,22 @@ func (f *FileConfig) GetCollectorType() (string, error) {
 	return f.conf.Collector, nil
 }
 
-func (f *FileConfig) GetSamplerType() (string, error) {
-	return f.conf.Sampler, nil
+func (f *FileConfig) GetDefaultSamplerType() (string, error) {
+	t := samplerConfigType{}
+	err := f.GetOtherConfig("SamplerConfig._default", &t)
+	if err != nil {
+		return "", err
+	}
+	return t.Sampler, nil
+}
+
+func (f *FileConfig) GetSamplerTypeForDataset(dataset string) (string, error) {
+	t := samplerConfigType{}
+	err := f.GetOtherConfig("SamplerConfig."+dataset, &t)
+	if err != nil {
+		return "", err
+	}
+	return t.Sampler, nil
 }
 
 func (f *FileConfig) GetMetricsType() (string, error) {
@@ -200,17 +223,17 @@ type MockConfig struct {
 	GetLoggingLevelVal  string
 	GetOtherConfigErr   error
 	// GetOtherConfigVal must be a JSON representation of the config struct to be populated.
-	GetOtherConfigVal  string
-	GetPeersErr        error
-	GetPeersVal        []string
-	GetSamplerTypeErr  error
-	GetSamplerTypeVal  string
-	GetMetricsTypeErr  error
-	GetMetricsTypeVal  string
-	GetSendDelayErr    error
-	GetSendDelayVal    int
-	GetTraceTimeoutErr error
-	GetTraceTimeoutVal int
+	GetOtherConfigVal        string
+	GetPeersErr              error
+	GetPeersVal              []string
+	GetDefaultSamplerTypeErr error
+	GetDefaultSamplerTypeVal string
+	GetMetricsTypeErr        error
+	GetMetricsTypeVal        string
+	GetSendDelayErr          error
+	GetSendDelayVal          int
+	GetTraceTimeoutErr       error
+	GetTraceTimeoutVal       int
 }
 
 func (m *MockConfig) ReloadConfig()                 {}
@@ -234,8 +257,15 @@ func (m *MockConfig) GetOtherConfig(name string, iface interface{}) error {
 	}
 	return m.GetOtherConfigErr
 }
-func (m *MockConfig) GetPeers() ([]string, error)     { return m.GetPeersVal, m.GetPeersErr }
-func (m *MockConfig) GetSamplerType() (string, error) { return m.GetSamplerTypeVal, m.GetSamplerTypeErr }
+func (m *MockConfig) GetPeers() ([]string, error) { return m.GetPeersVal, m.GetPeersErr }
+func (m *MockConfig) GetDefaultSamplerType() (string, error) {
+	return m.GetDefaultSamplerTypeVal, m.GetDefaultSamplerTypeErr
+}
 func (m *MockConfig) GetMetricsType() (string, error) { return m.GetMetricsTypeVal, m.GetMetricsTypeErr }
 func (m *MockConfig) GetSendDelay() (int, error)      { return m.GetSendDelayVal, m.GetSendDelayErr }
 func (m *MockConfig) GetTraceTimeout() (int, error)   { return m.GetTraceTimeoutVal, m.GetTraceTimeoutErr }
+
+// TODO: allow per-dataset mock values
+func (m *MockConfig) GetSamplerTypeForDataset(dataset string) (string, error) {
+	return m.GetDefaultSamplerTypeVal, m.GetDefaultSamplerTypeErr
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,1 +1,61 @@
 package config
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSamplerTypes(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	assert.Equal(t, nil, err)
+	defer os.RemoveAll(tmpDir)
+
+	f, err := ioutil.TempFile(tmpDir, "")
+	assert.Equal(t, nil, err)
+
+	dummyConfig := []byte(`
+[[SamplerConfig]]
+	[SamplerConfig._default]
+		Sampler = "DeterministicSampler"
+		SampleRate = 2
+
+	[SamplerConfig.dataset1]
+		Sampler = "DynamicSampler"
+		SampleRate = 2
+		FieldList = ["request.method","response.status_code"]
+		UseTraceLength = true
+		AddSampleRateKeyToTrace = true
+		AddSampleRateKeyToTraceField = "meta.samproxy.dynsampler_key"
+
+	[SamplerConfig.dataset2]
+
+		Sampler = "DeterministicSampler"
+		SampleRate = 10
+`)
+
+	_, err = f.Write(dummyConfig)
+	assert.Equal(t, nil, err)
+	f.Close()
+
+	var c Config
+	fc := &FileConfig{Path: f.Name()}
+	fc.Start()
+	c = fc
+	typ, err := c.GetDefaultSamplerType()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "DeterministicSampler", typ)
+
+	typ, err = c.GetSamplerTypeForDataset("dataset1")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "DynamicSampler", typ)
+
+	typ, err = c.GetSamplerTypeForDataset("dataset2")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "DeterministicSampler", typ)
+
+	typ, err = c.GetSamplerTypeForDataset("dataset3")
+	assert.Equal(t, "failed to find config tree", err.Error())
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -57,5 +57,5 @@ func TestGetSamplerTypes(t *testing.T) {
 	assert.Equal(t, "DeterministicSampler", typ)
 
 	typ, err = c.GetSamplerTypeForDataset("dataset3")
-	assert.Equal(t, "failed to find config tree", err.Error())
+	assert.Equal(t, "failed to find config tree for SamplerConfig.dataset3", err.Error())
 }

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/honeycombio/samproxy/config"
 	"github.com/honeycombio/samproxy/logger"
 	"github.com/honeycombio/samproxy/metrics"
+	"github.com/honeycombio/samproxy/sample"
 	"github.com/honeycombio/samproxy/sharder"
 	"github.com/honeycombio/samproxy/transmit"
 )
@@ -59,6 +60,7 @@ func main() {
 	collector := collect.GetCollectorImplementation(c)
 	metricsr := metrics.GetMetricsImplementation(c)
 	shrdr := sharder.GetSharderImplementation(c)
+	samplerFactory := &sample.SamplerFactory{}
 
 	// set log level
 	logLevel, err := c.GetLoggingLevel()
@@ -92,7 +94,7 @@ func main() {
 		&inject.Object{Value: collector},
 		&inject.Object{Value: metricsr},
 		&inject.Object{Value: version, Name: "version"},
-
+		&inject.Object{Value: samplerFactory},
 		&inject.Object{Value: &a},
 	)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/honeycombio/samproxy/config"
 	"github.com/honeycombio/samproxy/logger"
 	"github.com/honeycombio/samproxy/metrics"
-	"github.com/honeycombio/samproxy/sample"
 	"github.com/honeycombio/samproxy/sharder"
 	"github.com/honeycombio/samproxy/transmit"
 )
@@ -58,7 +57,6 @@ func main() {
 	// get desired implementation for each dependency to inject
 	lgr := logger.GetLoggerImplementation(c)
 	collector := collect.GetCollectorImplementation(c)
-	sampler := sample.GetSamplerImplementation(c)
 	metricsr := metrics.GetMetricsImplementation(c)
 	shrdr := sharder.GetSharderImplementation(c)
 
@@ -92,7 +90,6 @@ func main() {
 		&inject.Object{Value: &transmit.DefaultTransmission{}},
 		&inject.Object{Value: shrdr},
 		&inject.Object{Value: collector},
-		&inject.Object{Value: sampler},
 		&inject.Object{Value: metricsr},
 		&inject.Object{Value: version, Name: "version"},
 

--- a/sample/deterministic.go
+++ b/sample/deterministic.go
@@ -2,6 +2,7 @@ package sample
 
 import (
 	"crypto/sha1"
+	"fmt"
 	"math"
 
 	"github.com/honeycombio/samproxy/config"
@@ -15,6 +16,7 @@ type DeterministicSampler struct {
 
 	sampleRate int
 	upperBound uint32
+	configName string
 }
 
 type DetSamplerConfig struct {
@@ -38,7 +40,8 @@ func (d *DeterministicSampler) Start() error {
 
 func (d *DeterministicSampler) loadConfigs() error {
 	dsConfig := DetSamplerConfig{}
-	err := d.Config.GetOtherConfig("DeterministicSampler", &dsConfig)
+	configKey := fmt.Sprintf("SamplerConfig.%s", d.configName)
+	err := d.Config.GetOtherConfig(configKey, &dsConfig)
 	if err != nil {
 		return err
 	}

--- a/sample/deterministic.go
+++ b/sample/deterministic.go
@@ -11,8 +11,8 @@ import (
 )
 
 type DeterministicSampler struct {
-	Config config.Config `inject:""`
-	Logger logger.Logger `inject:""`
+	Config config.Config
+	Logger logger.Logger
 
 	sampleRate int
 	upperBound uint32

--- a/sample/dynamic.go
+++ b/sample/dynamic.go
@@ -15,9 +15,9 @@ import (
 )
 
 type DynamicSampler struct {
-	Config  config.Config   `inject:""`
-	Logger  logger.Logger   `inject:""`
-	Metrics metrics.Metrics `inject:""`
+	Config  config.Config
+	Logger  logger.Logger
+	Metrics metrics.Metrics
 
 	sampleRate        int64
 	fieldList         []string

--- a/sample/dynamic.go
+++ b/sample/dynamic.go
@@ -1,6 +1,7 @@
 package sample
 
 import (
+	"fmt"
 	"math/rand"
 	"sort"
 	"strconv"
@@ -23,6 +24,7 @@ type DynamicSampler struct {
 	useTraceLength    bool
 	addDynsampleKey   bool
 	addDynsampleField string
+	configName        string
 
 	dynsampler dynsampler.Sampler
 }
@@ -80,7 +82,8 @@ func (d *DynamicSampler) reloadConfigs() {
 	var configChanged bool
 
 	dsConfig := DynSamplerConfig{}
-	err := d.Config.GetOtherConfig("DynamicSampler", &dsConfig)
+	configKey := fmt.Sprintf("SamplerConfig.%s", d.configName)
+	err := d.Config.GetOtherConfig(configKey, &dsConfig)
 	if err != nil {
 		d.Logger.Errorf("Failed to get dynsampler settings when reloading configs:", err)
 	}

--- a/sample/dynamic.go
+++ b/sample/dynamic.go
@@ -39,7 +39,8 @@ type DynSamplerConfig struct {
 
 func (d *DynamicSampler) Start() error {
 	dsConfig := DynSamplerConfig{}
-	err := d.Config.GetOtherConfig("DynamicSampler", &dsConfig)
+	configKey := fmt.Sprintf("SamplerConfig.%s", d.configName)
+	err := d.Config.GetOtherConfig(configKey, &dsConfig)
 	if err != nil {
 		return err
 	}

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -5,6 +5,8 @@ import (
 	"os"
 
 	"github.com/honeycombio/samproxy/config"
+	"github.com/honeycombio/samproxy/logger"
+	"github.com/honeycombio/samproxy/metrics"
 	"github.com/honeycombio/samproxy/types"
 )
 
@@ -14,35 +16,46 @@ type Sampler interface {
 	GetSampleRate(trace *types.Trace) (rate uint, keep bool)
 }
 
+// SamplerFactory is used to create new samplers with common (injected) resources
+type SamplerFactory struct {
+	Config  config.Config   `inject:""`
+	Logger  logger.Logger   `inject:""`
+	Metrics metrics.Metrics `inject:""`
+}
+
 // GetDefaultSamplerImplementation returns the default sampler implementation
 // or exits fatally if not defined
-func GetDefaultSamplerImplementation(c config.Config) Sampler {
-	samplerType, err := c.GetDefaultSamplerType()
+func (s *SamplerFactory) GetDefaultSamplerImplementation() Sampler {
+	samplerType, err := s.Config.GetDefaultSamplerType()
 	if err != nil {
 		fmt.Printf("unable to get default sampler type from config: %v\n", err)
 		os.Exit(1)
 	}
 
-	return getSamplerForType(samplerType, defaultConfigName)
+	return s.getSamplerForType(samplerType, defaultConfigName)
 }
 
 // GetSamplerImplementationForDataset returns the sampler implementation for the dataset,
 // or nil if it is not defined
-func GetSamplerImplementationForDataset(c config.Config, dataset string) Sampler {
-	samplerType, err := c.GetSamplerTypeForDataset(dataset)
+func (s *SamplerFactory) GetSamplerImplementationForDataset(dataset string) Sampler {
+	samplerType, err := s.Config.GetSamplerTypeForDataset(dataset)
 	if err != nil {
 		return nil
 	}
-	return getSamplerForType(samplerType, dataset)
+	return s.getSamplerForType(samplerType, dataset)
 }
 
-func getSamplerForType(samplerType, configName string) Sampler {
+func (s *SamplerFactory) getSamplerForType(samplerType, configName string) Sampler {
 	var sampler Sampler
 	switch samplerType {
 	case "DeterministicSampler":
-		sampler = &DeterministicSampler{configName: configName}
+		ds := &DeterministicSampler{configName: configName, Config: s.Config, Logger: s.Logger}
+		ds.Start()
+		sampler = ds
 	case "DynamicSampler":
-		sampler = &DynamicSampler{configName: configName}
+		ds := &DynamicSampler{configName: configName, Config: s.Config, Logger: s.Logger, Metrics: s.Metrics}
+		ds.Start()
+		sampler = ds
 	default:
 		fmt.Printf("unknown sampler type %s. Exiting.\n", samplerType)
 		os.Exit(1)

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -1,7 +1,6 @@
 package sample
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/honeycombio/samproxy/config"
@@ -28,10 +27,10 @@ type SamplerFactory struct {
 func (s *SamplerFactory) GetDefaultSamplerImplementation() Sampler {
 	samplerType, err := s.Config.GetDefaultSamplerType()
 	if err != nil {
-		fmt.Printf("unable to get default sampler type from config: %v\n", err)
+		s.Logger.Errorf("unable to get default sampler type from config: %s", err.Error())
 		os.Exit(1)
 	}
-
+	s.Logger.Debugf("creating default sampler implementation")
 	return s.getSamplerForType(samplerType, defaultConfigName)
 }
 
@@ -42,6 +41,7 @@ func (s *SamplerFactory) GetSamplerImplementationForDataset(dataset string) Samp
 	if err != nil {
 		return nil
 	}
+	s.Logger.Debugf("creating sampler implementation for %s", dataset)
 	return s.getSamplerForType(samplerType, dataset)
 }
 
@@ -57,8 +57,9 @@ func (s *SamplerFactory) getSamplerForType(samplerType, configName string) Sampl
 		ds.Start()
 		sampler = ds
 	default:
-		fmt.Printf("unknown sampler type %s. Exiting.\n", samplerType)
+		s.Logger.Errorf("unknown sampler type %s. Exiting.", samplerType)
 		os.Exit(1)
 	}
+
 	return sampler
 }

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -8,22 +8,41 @@ import (
 	"github.com/honeycombio/samproxy/types"
 )
 
+const defaultConfigName = "_default"
+
 type Sampler interface {
 	GetSampleRate(trace *types.Trace) (rate uint, keep bool)
 }
 
-func GetSamplerImplementation(c config.Config) Sampler {
-	var sampler Sampler
-	samplerType, err := c.GetSamplerType()
+// GetDefaultSamplerImplementation returns the default sampler implementation
+// or exits fatally if not defined
+func GetDefaultSamplerImplementation(c config.Config) Sampler {
+	samplerType, err := c.GetDefaultSamplerType()
 	if err != nil {
-		fmt.Printf("unable to get sampler type from config: %v\n", err)
+		fmt.Printf("unable to get default sampler type from config: %v\n", err)
 		os.Exit(1)
 	}
+
+	return getSamplerForType(samplerType, defaultConfigName)
+}
+
+// GetSamplerImplementationForDataset returns the sampler implementation for the dataset,
+// or nil if it is not defined
+func GetSamplerImplementationForDataset(c config.Config, dataset string) Sampler {
+	samplerType, err := c.GetSamplerTypeForDataset(dataset)
+	if err != nil {
+		return nil
+	}
+	return getSamplerForType(samplerType, dataset)
+}
+
+func getSamplerForType(samplerType, configName string) Sampler {
+	var sampler Sampler
 	switch samplerType {
 	case "DeterministicSampler":
-		sampler = &DeterministicSampler{}
+		sampler = &DeterministicSampler{configName: configName}
 	case "DynamicSampler":
-		sampler = &DynamicSampler{}
+		sampler = &DynamicSampler{configName: configName}
 	default:
 		fmt.Printf("unknown sampler type %s. Exiting.\n", samplerType)
 		os.Exit(1)


### PR DESCRIPTION
Replaces the global sampler type and sampler config with a default config, and optional per-dataset configs. Before calling GetSampleRate, check for a per-dataset sampler and use that instead.

TODO - actually run this. Also, make hot reloading of configs work.