### PR TITLE
add hostname to metrics and logs for better tracking

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -220,7 +220,7 @@ func (i *InMemCollector) send(trace *types.Trace) {
 
 	if trace.Sent == true {
 		// someone else already sent this. Return doing nothing.
-		i.Logger.Debugf("skipping send because someone else already sent, trace ID %s", trace.TraceID)
+		i.Logger.Debugf("skipping send because someone else already sent, trace ID %s to dataset %s", trace.TraceID, trace.Dataset)
 		return
 	}
 
@@ -256,12 +256,12 @@ func (i *InMemCollector) send(trace *types.Trace) {
 
 	// if we're supposed to drop this trace, then we're done.
 	if !shouldSend {
-		i.Logger.Infof("Dropping trace because of sampling, trace ID %s", trace.TraceID)
+		i.Logger.Infof("Dropping trace because of sampling, trace ID %s to dataset %s", trace.TraceID, trace.Dataset)
 		return
 	}
 
 	// ok, we're not dropping this trace; send all the spans
-	i.Logger.Infof("Sending trace ID %s", trace.TraceID)
+	i.Logger.Infof("Sending trace ID %s to dataset %s", trace.TraceID, trace.Dataset)
 	for _, sp := range trace.Spans {
 		if sp.SampleRate < 1 {
 			sp.SampleRate = 1

--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	libhoney "github.com/honeycombio/libhoney-go"
@@ -56,6 +57,10 @@ func (h *HoneycombLogger) Start() error {
 	}
 	h.builder = libhoney.NewBuilder()
 	h.builder.Dataset = h.loggerConfig.LoggerDataset
+
+	if hostname, err := os.Hostname(); err == nil {
+		h.builder.AddField("hostname", hostname)
+	}
 
 	// listen for config reloads
 	h.Config.RegisterReloadCallback(h.reloadBuilder)

--- a/metrics/honeycomb.go
+++ b/metrics/honeycomb.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 	"net/http"
+	"os"
 	"runtime"
 	"sort"
 	"sync"
@@ -88,6 +89,9 @@ func (h *HoneycombMetrics) Start() error {
 
 	// add some general go metrics to every report
 	// goroutines
+	if hostname, err := os.Hostname(); err == nil {
+		h.builder.AddField("hostname", hostname)
+	}
 	h.builder.AddDynamicField("num_goroutines",
 		func() interface{} { return runtime.NumGoroutine() })
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Mistakenly, it's impossible to look at memory used per server because there's no field identifying the samproxy instance that is sending in the metrics and logs. This change adds one.

(along for the ride are three small log content improvements.)