### PR TITLE
find out if it's span or span.Data that's nil and causing a panic

### DIFF
--- a/sample/dynamic.go
+++ b/sample/dynamic.go
@@ -166,6 +166,14 @@ func (d *DynamicSampler) buildKey(trace *types.Trace) string {
 	// for each field, for each span, get the value of that field
 	for _, field := range d.fieldList {
 		for _, span := range trace.Spans {
+			if span == nil {
+				d.Logger.Errorf("span is nil for trace %s. Trace %+v", trace.TraceID, trace)
+				return ""
+			}
+			if span.Data == nil {
+				d.Logger.Errorf("span.Data is nil for trace %s. Span %+v", trace.TraceID, span)
+				return ""
+			}
 			if val, ok := span.Data[field]; ok {
 				switch val := val.(type) {
 				case string:


### PR DESCRIPTION
I caught a panic accessing `span.Data[field]`. Might be a race, but at the least I'm curious to catch it with an error and hopefully get a little more insight into where it's coming from.