### PR TITLE
fix race around span list by protecting its access with a lock

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -127,34 +127,20 @@ func (i *InMemCollector) AddSpan(sp *types.Span) {
 	trace := i.Cache.Get(sp.TraceID)
 	if trace == nil {
 		ctx, cancel := context.WithCancel(context.Background())
-		spans := make([]*types.Span, 0, 1)
-		spans = append(spans, sp)
 		trace = &types.Trace{
 			APIHost:       sp.APIHost,
 			APIKey:        sp.APIKey,
 			Dataset:       sp.Dataset,
 			TraceID:       sp.TraceID,
-			Spans:         spans,
 			StartTime:     time.Now(),
 			CancelSending: cancel,
 		}
 		i.Cache.Set(trace)
 		go i.timeoutThenSend(ctx, trace)
-	} else {
-		// we found a trace; add this span to it
-		trace.Spans = append(trace.Spans, sp)
 	}
-
-	// if this trace has already gotten sent (aka we're a straggler), skip the
-	// rest and obey the existing sample / send decision
-	if trace.GetSent() {
-		if trace.KeepSample {
-			i.Logger.Debugf("Sending span because of previous decision to send trace %s", sp.TraceID)
-			sp.SampleRate *= trace.SampleRate
-			i.Transmission.EnqueueSpan(sp)
-			return
-		}
-		i.Logger.Debugf("Dropping span because of previous decision to drop trace %s", sp.TraceID)
+	err := trace.AddSpan(sp)
+	if err == types.TraceAlreadySent {
+		i.dealWithSentTrace(trace, sp)
 		return
 	}
 
@@ -162,6 +148,18 @@ func (i *InMemCollector) AddSpan(sp *types.Span) {
 	if isRootSpan(sp) {
 		go i.pauseAndSend(trace)
 	}
+}
+
+func (i *InMemCollector) dealWithSentTrace(tr *types.Trace, sp *types.Span) {
+	if tr.KeepSample {
+		i.Logger.Debugf("Sending span because of previous decision to send trace %s", sp.TraceID)
+		sp.SampleRate *= tr.SampleRate
+		i.Transmission.EnqueueSpan(sp)
+		return
+	}
+	i.Logger.Debugf("Dropping span because of previous decision to drop trace %s", sp.TraceID)
+	return
+
 }
 
 func isRootSpan(sp *types.Span) bool {
@@ -230,7 +228,7 @@ func (i *InMemCollector) send(trace *types.Trace) {
 	traceDur := float64(trace.FinishTime.Sub(trace.StartTime) / time.Millisecond)
 	i.Metrics.Histogram("trace_duration_ms", traceDur)
 
-  var sampler sample.Sampler
+	var sampler sample.Sampler
 	var found bool
 
 	if sampler, found = i.datasetSamplers[trace.Dataset]; !found {
@@ -262,7 +260,7 @@ func (i *InMemCollector) send(trace *types.Trace) {
 
 	// ok, we're not dropping this trace; send all the spans
 	i.Logger.Infof("Sending trace ID %s to dataset %s", trace.TraceID, trace.Dataset)
-	for _, sp := range trace.Spans {
+	for _, sp := range trace.GetSpans() {
 		if sp.SampleRate < 1 {
 			sp.SampleRate = 1
 		}

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -111,7 +111,6 @@ func (i *InMemCollector) reloadConfigs() {
 				if i > capacity {
 					break
 				}
-				fmt.Printf(".")
 				c.Set(trace)
 			}
 			i.Cache = c

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -118,7 +118,7 @@ func TestAddSpan(t *testing.T) {
 	}
 	coll.AddSpan(rootSpan)
 	time.Sleep(10 * time.Millisecond)
-	assert.Equal(t, 2, len(coll.Cache.Get(traceID).Spans), "after adding a leaf and root span, we should have a two spans in the cache")
+	assert.Equal(t, 2, len(coll.Cache.Get(traceID).GetSpans()), "after adding a leaf and root span, we should have a two spans in the cache")
 	assert.Equal(t, 2, len(transmission.Events), "adding a root span should send all spans in the trace")
 
 }

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -59,7 +59,7 @@ func TestAddRootSpan(t *testing.T) {
 	// * create the trace in the cache
 	// * send the trace
 	assert.Equal(t, traceID, coll.Cache.Get(traceID).TraceID, "after adding the span, we should have a trace in the cache with the right trace ID")
-	assert.Equal(t, 1, len(transmission.Events), "adding a non-root span should not yet send the span")
+	assert.Equal(t, 1, len(transmission.Events), "adding a root span should send the span")
 	assert.Equal(t, "aoeu", transmission.Events[0].Dataset, "sending a root span should immediately send that span via transmission")
 }
 

--- a/sample/dynamic.go
+++ b/sample/dynamic.go
@@ -167,14 +167,6 @@ func (d *DynamicSampler) buildKey(trace *types.Trace) string {
 	spans := trace.GetSpans()
 	for _, field := range d.fieldList {
 		for _, span := range spans {
-			if span == nil {
-				d.Logger.Errorf("span is nil for trace %s. Trace %+v", trace.TraceID, trace)
-				return ""
-			}
-			if span.Data == nil {
-				d.Logger.Errorf("span.Data is nil for trace %s. Span %+v", trace.TraceID, span)
-				return ""
-			}
 			if val, ok := span.Data[field]; ok {
 				switch val := val.(type) {
 				case string:

--- a/sample/dynamic.go
+++ b/sample/dynamic.go
@@ -164,8 +164,9 @@ func (d *DynamicSampler) buildKey(trace *types.Trace) string {
 	fieldCollector := map[string][]string{}
 
 	// for each field, for each span, get the value of that field
+	spans := trace.GetSpans()
 	for _, field := range d.fieldList {
-		for _, span := range trace.Spans {
+		for _, span := range spans {
 			if span == nil {
 				d.Logger.Errorf("span is nil for trace %s. Trace %+v", trace.TraceID, trace)
 				return ""
@@ -205,7 +206,7 @@ func (d *DynamicSampler) buildKey(trace *types.Trace) string {
 		key += ","
 	}
 	if d.useTraceLength {
-		key += strconv.FormatInt(int64(len(trace.Spans)), 10)
+		key += strconv.FormatInt(int64(len(spans)), 10)
 	}
 
 	// if we should add the key used by the dynsampler to the root span, let's
@@ -225,7 +226,7 @@ func (d *DynamicSampler) buildKey(trace *types.Trace) string {
 // findRootSpan selects the root span from the list of spans in a trace. If it
 // can't find a root span it returns nil.
 func findRootSpan(trace *types.Trace) *types.Span {
-	for _, span := range trace.Spans {
+	for _, span := range trace.GetSpans() {
 		if isRootSpan(span) {
 			return span
 		}

--- a/types/event.go
+++ b/types/event.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 )
@@ -14,6 +15,8 @@ const (
 
 // used to put a request ID into the request context for logging
 type RequestIDContextKey struct{}
+
+var TraceAlreadySent = errors.New("Can't add span; trace has already been sent.")
 
 // event is not part of a trace - it's an event that showed up with no trace ID
 type Event struct {
@@ -32,7 +35,6 @@ type Trace struct {
 	APIKey  string
 	Dataset string
 	TraceID string
-	Spans   []*Span
 
 	// SendSampleLock protects the SampleRate and KeepSample attributes of the
 	// trace because they should be modified together. It is accessed from here
@@ -57,6 +59,13 @@ type Trace struct {
 	// goroutines waiting a full minute (or whatever the trace timeout is) then
 	// doing nothing.
 	CancelSending context.CancelFunc
+
+	// spanListLock protects multiple accessors to the list of spans in this
+	// trace
+	spanListLock sync.Mutex
+
+	// spans is the list of spans in this trace, protected by the list lock
+	spans []*Span
 }
 
 // GetSent returns true if this trace has already been sent, false if it has not
@@ -65,6 +74,32 @@ func (t *Trace) GetSent() bool {
 	t.SendSampleLock.Lock()
 	defer t.SendSampleLock.Unlock()
 	return t.Sent
+}
+
+// AddSpan adds a span to this trace
+func (t *Trace) AddSpan(sp *Span) error {
+	t.SendSampleLock.Lock()
+	defer t.SendSampleLock.Unlock()
+	if t.Sent {
+		return TraceAlreadySent
+	}
+	t.spanListLock.Lock()
+	defer t.spanListLock.Unlock()
+	if t.spans == nil {
+		t.spans = make([]*Span, 0, 1)
+	}
+	t.spans = append(t.spans, sp)
+	return nil
+}
+
+// GetSpans returns the list of spans in this trace
+func (t *Trace) GetSpans() []*Span {
+	t.spanListLock.Lock()
+	defer t.spanListLock.Unlock()
+	spans := make([]*Span, 0, len(t.spans))
+	copy(spans, t.spans)
+	return spans
+
 }
 
 // Span is an event that shows up with a trace ID, so will be part of a Trace

--- a/types/event.go
+++ b/types/event.go
@@ -96,7 +96,7 @@ func (t *Trace) AddSpan(sp *Span) error {
 func (t *Trace) GetSpans() []*Span {
 	t.spanListLock.Lock()
 	defer t.spanListLock.Unlock()
-	spans := make([]*Span, 0, len(t.spans))
+	spans := make([]*Span, len(t.spans))
 	copy(spans, t.spans)
 	return spans
 

--- a/types/event.go
+++ b/types/event.go
@@ -85,9 +85,6 @@ func (t *Trace) AddSpan(sp *Span) error {
 	}
 	t.spanListLock.Lock()
 	defer t.spanListLock.Unlock()
-	if t.spans == nil {
-		t.spans = make([]*Span, 0, 1)
-	}
 	t.spans = append(t.spans, sp)
 	return nil
 }
@@ -96,9 +93,9 @@ func (t *Trace) AddSpan(sp *Span) error {
 func (t *Trace) GetSpans() []*Span {
 	t.spanListLock.Lock()
 	defer t.spanListLock.Unlock()
-	spans := make([]*Span, len(t.spans))
-	copy(spans, t.spans)
-	return spans
+	// since we only ever append to this list, we can return a new reference to
+	// the slice as it exists now and it will be safe for concurrent reads.
+	return t.spans[:]
 
 }
 


### PR DESCRIPTION
If a span were to arrive right around when a trace's timer went off, you'd get concurrent access to the list of spans when the collector tries to add a new span while the sending function is trying to iterate across those spans. This can cause the iterator to get a nil span out of the list.

In addition to protecting the span list with a lock this change removes the nil span protection that was in the dynsampler because it should no longer be necessary; there is no case where it should get a nil span. A panic there is nice to help make sure that's true.