### PR TITLE
[route] fix batch response when event is forwarded to peer

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -272,6 +272,10 @@ func (r *Router) batch(w http.ResponseWriter, req *http.Request) {
 				)
 				continue
 			}
+			batchedResponses = append(
+				batchedResponses,
+				&BatchResponse{Status: http.StatusAccepted},
+			)
 			ev.APIHost = targetShard.GetAddress()
 			r.Transmission.EnqueueEvent(ev)
 			continue


### PR DESCRIPTION
Even though we forward a span to a peer, we should acknowledge the event in the response to the client.