### PR TITLE
swap out goroutine based trace timeouts for a channel to lighten load

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -135,7 +135,7 @@ CacheCapacity = 1000
 		# will keep 1 out of every 30 traces. The choice on whether to keep any specific
 		# trace is random, so the rate is approximate.
 		# Eligible for live reload.
-		SampleRate = 2
+		SampleRate = 1
 
 	[SamplerConfig.dataset1]
 

--- a/types/event.go
+++ b/types/event.go
@@ -54,12 +54,6 @@ type Trace struct {
 	// any additional delay imposed by the DelaySend config option.
 	FinishTime time.Time
 
-	// CanceSending is a cancel function to abort the trace timeout if we send
-	// or sample this trace so that we're not sitting around with tons of
-	// goroutines waiting a full minute (or whatever the trace timeout is) then
-	// doing nothing.
-	CancelSending context.CancelFunc
-
 	// spanListLock protects multiple accessors to the list of spans in this
 	// trace
 	spanListLock sync.Mutex


### PR DESCRIPTION
I'm not sure this actually makes much of a difference.  It'd be interesting to try it out and see. Or at least just take a look to see if it's a useful place to think about how to lighten the load in this proxy.