### PR TITLE
[logger] ensure HoneycombLogger does not drop loglevel setting

### DIFF
--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -40,11 +40,17 @@ const (
 )
 
 func (h *HoneycombLogger) Start() error {
+	// logLevel is defined outside the HoneycombLogger section
+	// and is set independently, before Start() is called, so we need to
+	// preserve it.
+	// TODO: make LogLevel part of the HoneycombLogger/LogrusLogger sections?
+	logLevel := h.loggerConfig.level
 	loggerConfig := HoneycombLoggerConfig{}
 	err := h.Config.GetOtherConfig("HoneycombLogger", &loggerConfig)
 	if err != nil {
 		return err
 	}
+	loggerConfig.level = logLevel
 	h.loggerConfig = loggerConfig
 	if h.loggerConfig.LoggerAPIKey != "" {
 		libhConf := libhoney.Config{
@@ -69,6 +75,8 @@ func (h *HoneycombLogger) Start() error {
 }
 
 func (h *HoneycombLogger) reloadBuilder() {
+	// preseve log level
+	logLevel := h.loggerConfig.level
 	loggerConfig := HoneycombLoggerConfig{}
 	err := h.Config.GetOtherConfig("HoneycombLogger", &loggerConfig)
 	if err != nil {
@@ -78,6 +86,7 @@ func (h *HoneycombLogger) reloadBuilder() {
 		h.Errorf("failed to reload configs for Honeycomb logger: %+v", err)
 		return
 	}
+	loggerConfig.level = logLevel
 	h.loggerConfig = loggerConfig
 	h.builder.APIHost = h.loggerConfig.LoggerHoneycombAPI
 	h.builder.WriteKey = h.loggerConfig.LoggerAPIKey

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,1 +1,22 @@
 package logger
+
+import (
+	"testing"
+
+	"github.com/honeycombio/samproxy/config"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHoneycombLoggerRespectsLogLevelAfterStart(t *testing.T) {
+	cfg := &config.MockConfig{GetOtherConfigVal: `{}`}
+	hcLogger := &HoneycombLogger{
+		Config:       cfg,
+		loggerConfig: HoneycombLoggerConfig{level: WarnLevel},
+	}
+
+	assert.Equal(t, WarnLevel, hcLogger.loggerConfig.level)
+	err := hcLogger.Start()
+	assert.Nil(t, err)
+	assert.Equal(t, WarnLevel, hcLogger.loggerConfig.level)
+}


### PR DESCRIPTION
We set LogLevel before HoneycombLogger.Start is called. Currently, start creates a new HoneycombLoggerConfig object,
then fills it with values from the config file. Since the HoneycombLogger section does not include log level, we effectively
reset the loglevel value to 0 and log everything.