### PR TITLE
missed log line with unstructured content

### DIFF
--- a/route/errors.go
+++ b/route/errors.go
@@ -38,7 +38,11 @@ func (r *Router) handlerReturnWithError(w http.ResponseWriter, he handlerError, 
 	if err != nil {
 		he.err = err
 	}
-	r.Logger.Errorf("returning error %+v, %s\n", he, he.err.Error())
+	r.Logger.WithFields(map[string]interface{}{
+		"error.err":         he.err.Error(),
+		"error.msg":         he.msg,
+		"error.status_code": he.status,
+	}).Errorf("handler returning error")
 	w.WriteHeader(he.status)
 	errmsg := he.msg
 	if he.detailed {


### PR DESCRIPTION
There is a log that spits something like `returning error {err:0xc46e2147b0 msg:unknown API key - check your credentials status:400 detailed:true friendly:true}, no X-Honeycomb-Team header found from within authing middleware` into the `msg` field, polluting the breakdown. This change puts "handler returned error" into the `msg` field and pulls the rest of that content out into their own fields.
