### PR TITLE
Add instrumentation, enable blockOnSend in libhoney

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -98,7 +98,6 @@ func (i *InMemCollector) Start() error {
 	i.Metrics.Register("trace_num_spans", "histogram")
 	i.Metrics.Register("trace_sent_cache_hit", "counter")
 	i.Metrics.Register("trace_accepted", "counter")
-	i.Metrics.Register("trace_send", "counter")
 	i.Metrics.Register("trace_send_kept", "counter")
 	i.Metrics.Register("trace_send_dropped", "counter")
 

--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -63,6 +63,8 @@ func (h *HoneycombLogger) Start() error {
 			WriteKey: h.loggerConfig.LoggerAPIKey,
 			// Output:   &libhoney.WriterOutput{},
 			// Logger: &libhoney.DefaultLogger{},
+			BlockOnSend:     true,
+			BlockOnResponse: true,
 		}
 		libhoney.Init(libhConf)
 	}
@@ -129,6 +131,10 @@ func (h *HoneycombLogger) Debugf(f string, args ...interface{}) {
 	ev := h.builder.NewEvent()
 	ev.AddField("level", "debug")
 	ev.AddField("msg", fmt.Sprintf(f, args...))
+	ev.Metadata = map[string]string{
+		"api_host": ev.APIHost,
+		"dataset":  ev.Dataset,
+	}
 	ev.Send()
 }
 
@@ -139,6 +145,10 @@ func (h *HoneycombLogger) Infof(f string, args ...interface{}) {
 	ev := h.builder.NewEvent()
 	ev.AddField("level", "info")
 	ev.AddField("msg", fmt.Sprintf(f, args...))
+	ev.Metadata = map[string]string{
+		"api_host": ev.APIHost,
+		"dataset":  ev.Dataset,
+	}
 	ev.Send()
 }
 
@@ -149,6 +159,10 @@ func (h *HoneycombLogger) Errorf(f string, args ...interface{}) {
 	ev := h.builder.NewEvent()
 	ev.AddField("level", "error")
 	ev.AddField("msg", fmt.Sprintf(f, args...))
+	ev.Metadata = map[string]string{
+		"api_host": ev.APIHost,
+		"dataset":  ev.Dataset,
+	}
 	ev.Send()
 }
 
@@ -190,6 +204,10 @@ func (h *HoneycombEntry) Debugf(f string, args ...interface{}) {
 	ev := h.builder.NewEvent()
 	ev.AddField("level", "debug")
 	ev.AddField("msg", fmt.Sprintf(f, args...))
+	ev.Metadata = map[string]string{
+		"api_host": ev.APIHost,
+		"dataset":  ev.Dataset,
+	}
 	ev.Send()
 }
 
@@ -200,6 +218,10 @@ func (h *HoneycombEntry) Infof(f string, args ...interface{}) {
 	ev := h.builder.NewEvent()
 	ev.AddField("level", "info")
 	ev.AddField("msg", fmt.Sprintf(f, args...))
+	ev.Metadata = map[string]string{
+		"api_host": ev.APIHost,
+		"dataset":  ev.Dataset,
+	}
 	ev.Send()
 }
 
@@ -210,5 +232,9 @@ func (h *HoneycombEntry) Errorf(f string, args ...interface{}) {
 	ev := h.builder.NewEvent()
 	ev.AddField("level", "error")
 	ev.AddField("msg", fmt.Sprintf(f, args...))
+	ev.Metadata = map[string]string{
+		"api_host": ev.APIHost,
+		"dataset":  ev.Dataset,
+	}
 	ev.Send()
 }

--- a/metrics/honeycomb.go
+++ b/metrics/honeycomb.go
@@ -190,6 +190,10 @@ func (h *HoneycombMetrics) reportToHoneycommb(ctx context.Context) {
 			return
 		case <-tick.C:
 			ev := h.builder.NewEvent()
+			ev.Metadata = map[string]string{
+				"api_host": ev.APIHost,
+				"dataset":  ev.Dataset,
+			}
 			h.countersLock.Lock()
 			for _, count := range h.counters {
 				count.lock.Lock()

--- a/metrics/honeycomb.go
+++ b/metrics/honeycomb.go
@@ -79,6 +79,7 @@ func (h *HoneycombMetrics) Start() error {
 		APIHost:   mc.MetricsHoneycombAPI,
 		Transport: h.HTTPClient.Transport,
 		// Logger:    &libhoney.DefaultLogger{},
+		BlockOnSend: true,
 	}
 	libhoney.Init(libhConfig)
 	libhoney.UserAgentAddition = "samproxy/" + h.Version

--- a/metrics/honeycomb.go
+++ b/metrics/honeycomb.go
@@ -79,7 +79,8 @@ func (h *HoneycombMetrics) Start() error {
 		APIHost:   mc.MetricsHoneycombAPI,
 		Transport: h.HTTPClient.Transport,
 		// Logger:    &libhoney.DefaultLogger{},
-		BlockOnSend: true,
+		BlockOnSend:     true,
+		BlockOnResponse: true,
 	}
 	libhoney.Init(libhConfig)
 	libhoney.UserAgentAddition = "samproxy/" + h.Version

--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -105,7 +105,7 @@ func (d *DefaultTransmission) EnqueueEvent(ev *types.Event) {
 			"request_id": ev.Context.Value(types.RequestIDContextKey{}),
 			"dataset":    ev.Dataset,
 			"api_host":   ev.APIHost,
-		}).Errorf("failed to enque event")
+		}).Errorf("failed to enqueue event")
 	}
 }
 
@@ -140,10 +140,10 @@ func (d *DefaultTransmission) processResponses(ctx context.Context) {
 				}
 				d.Logger.WithFields(map[string]interface{}{
 					"status_code": r.StatusCode,
-					"error":       r.Err,
+					"error":       r.Err.Error(),
 					"api_host":    apiHost,
 					"dataset":     dataset,
-				}).Infof("non-20x response when sending event")
+				}).Errorf("non-20x response when sending event")
 				if honeycombAPI == apiHost {
 					// if the API host matches the configured honeycomb API,
 					// count it as an API error

--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -1,12 +1,14 @@
 package transmit
 
 import (
+	"context"
 	"net/http"
 
 	libhoney "github.com/honeycombio/libhoney-go"
 
 	"github.com/honeycombio/samproxy/config"
 	"github.com/honeycombio/samproxy/logger"
+	"github.com/honeycombio/samproxy/metrics"
 	"github.com/honeycombio/samproxy/types"
 )
 
@@ -18,13 +20,22 @@ type Transmission interface {
 	Flush()
 }
 
-type DefaultTransmission struct {
-	Config     config.Config `inject:""`
-	Logger     logger.Logger `inject:""`
-	HTTPClient *http.Client  `inject:"upstreamClient"`
-	Version    string        `inject:"version"`
+const (
+	counterEnqueueErrors      = "enqueue_errors"
+	counterResponse20x        = "response_20x"
+	counterResponseErrorsAPI  = "response_errors_api"
+	counterResponseErrorsPeer = "response_errors_peer"
+)
 
-	builder *libhoney.Builder
+type DefaultTransmission struct {
+	Config     config.Config   `inject:""`
+	Logger     logger.Logger   `inject:""`
+	HTTPClient *http.Client    `inject:"upstreamClient"`
+	Metrics    metrics.Metrics `inject:""`
+	Version    string          `inject:"version"`
+
+	builder          *libhoney.Builder
+	responseCanceler context.CancelFunc
 }
 
 func (d *DefaultTransmission) Start() error {
@@ -40,6 +51,15 @@ func (d *DefaultTransmission) Start() error {
 	libhoney.Init(libhConfig)
 	libhoney.UserAgentAddition = "samproxy/" + d.Version
 	d.builder = libhoney.NewBuilder()
+
+	d.Metrics.Register(counterEnqueueErrors, "counter")
+	d.Metrics.Register(counterResponse20x, "counter")
+	d.Metrics.Register(counterResponseErrorsAPI, "counter")
+	d.Metrics.Register(counterResponseErrorsPeer, "counter")
+
+	processCtx, canceler := context.WithCancel(context.Background())
+	d.responseCanceler = canceler
+	go d.processResponses(processCtx)
 
 	// listen for config reloads
 	d.Config.RegisterReloadCallback(d.reloadTransmissionBuilder)
@@ -68,12 +88,25 @@ func (d *DefaultTransmission) EnqueueEvent(ev *types.Event) {
 	libhEv.Dataset = ev.Dataset
 	libhEv.SampleRate = ev.SampleRate
 	libhEv.Timestamp = ev.Timestamp
+	libhEv.Metadata = map[string]string{
+		"api_host": ev.APIHost,
+		"dataset":  ev.Dataset,
+	}
 
 	for k, v := range ev.Data {
 		libhEv.AddField(k, v)
 	}
 
-	libhEv.SendPresampled()
+	err := libhEv.SendPresampled()
+	if err != nil {
+		d.Metrics.IncrementCounter(counterEnqueueErrors)
+		d.Logger.WithFields(map[string]interface{}{
+			"error":      err.Error(),
+			"request_id": ev.Context.Value(types.RequestIDContextKey{}),
+			"dataset":    ev.Dataset,
+			"api_host":   ev.APIHost,
+		}).Errorf("failed to enque event")
+	}
 }
 
 func (d *DefaultTransmission) EnqueueSpan(sp *types.Span) {
@@ -86,7 +119,44 @@ func (d *DefaultTransmission) Flush() {
 }
 
 func (d *DefaultTransmission) Stop() error {
+	// signal processResponses to stop
+	d.responseCanceler()
 	// purge the queue of any in-flight events
 	libhoney.Flush()
 	return nil
+}
+
+func (d *DefaultTransmission) processResponses(ctx context.Context) {
+	honeycombAPI, _ := d.Config.GetHoneycombAPI()
+	responses := libhoney.Responses()
+	for {
+		select {
+		case r := <-responses:
+			if r.StatusCode != 200 && r.StatusCode != 202 {
+				var apiHost, dataset string
+				if metadata, ok := r.Metadata.(map[string]string); ok {
+					apiHost = metadata["api_host"]
+					dataset = metadata["dataset"]
+				}
+				d.Logger.WithFields(map[string]interface{}{
+					"status_code": r.StatusCode,
+					"error":       r.Err,
+					"api_host":    apiHost,
+					"dataset":     dataset,
+				}).Infof("non-20x response when sending event")
+				if honeycombAPI == apiHost {
+					// if the API host matches the configured honeycomb API,
+					// count it as an API error
+					d.Metrics.IncrementCounter(counterResponseErrorsAPI)
+				} else {
+					// otherwise, it's probably a peer error
+					d.Metrics.IncrementCounter(counterResponseErrorsPeer)
+				}
+			} else {
+				d.Metrics.IncrementCounter(counterResponse20x)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
 }

--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -47,6 +47,8 @@ func (d *DefaultTransmission) Start() error {
 		APIHost:   upstreamAPI,
 		Transport: d.HTTPClient.Transport,
 		// Logger:    &libhoney.DefaultLogger{},
+		BlockOnResponse: true,
+		BlockOnSend:     true,
 	}
 	libhoney.Init(libhConfig)
 	libhoney.UserAgentAddition = "samproxy/" + d.Version


### PR DESCRIPTION
 Libhoney has a default send queue size of a 1000. After that, we drop things on the floor. This is might be OK when the library is being used inside an instrumented application, but since we're responsible for making sure every event we get gets handled, it is not ok for samproxy. Configuring blockOnSend in the libhoney config to true. This could lead to other issues, like OOMing if there's a large backlog of unsent traces and the goroutines trying to send them pile up. We'll have to see.

I am also adding a response queue processor in the DefaultTransmission implementation. This gives us some maybe useful logging if we get non-200 responses from the API or our peer. Also added some counters to keep track of errors.