### PR TITLE
Separate peer/upstream clients, disable gzip on peer communications

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/gorilla/mux v1.6.3-0.20190108142930-08e7f807d38d
 	github.com/hashicorp/golang-lru v0.5.0
 	github.com/honeycombio/dynsampler-go v0.0.0-20171107180038-7f9929d9ca1f
-	github.com/honeycombio/libhoney-go v1.9.1
+	github.com/honeycombio/libhoney-go v1.9.2
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,13 +32,8 @@ github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCO
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/honeycombio/dynsampler-go v0.0.0-20171107180038-7f9929d9ca1f h1:CavWxcRtxHoNGHiz8KvjCOaXTM0rUwh9w9qT+ytfK/E=
 github.com/honeycombio/dynsampler-go v0.0.0-20171107180038-7f9929d9ca1f/go.mod h1:BOeTUPT6fCRH5X/+QqF6Kza3IyLp9uSq/rWgEtI4aZI=
-github.com/honeycombio/libhoney-go v1.8.1 h1:ZNa8QacttKO/628Nm4Bb0H6ur7i9dy7z/BUuA36VJKk=
-github.com/honeycombio/libhoney-go v1.8.1/go.mod h1:jdLxh51fcBTy6XIpx1efuJmHePs2xUfVkw25lr+hsmg=
-github.com/honeycombio/libhoney-go v1.8.2 h1:stYQJi/21p37Qan2DlSkXDuIrup9zxOul2UyeqMAqX0=
-github.com/honeycombio/libhoney-go v1.9.0 h1:EFJE1mh9Ewb3XO4C067S2sb2+P8MtzV3vveppba3Pgw=
-github.com/honeycombio/libhoney-go v1.9.0/go.mod h1:jdLxh51fcBTy6XIpx1efuJmHePs2xUfVkw25lr+hsmg=
-github.com/honeycombio/libhoney-go v1.9.1 h1:1AbIs9nzXn7aLztyUthr8yAJgKdBfYMkVwVc3Z92alE=
-github.com/honeycombio/libhoney-go v1.9.1/go.mod h1:jdLxh51fcBTy6XIpx1efuJmHePs2xUfVkw25lr+hsmg=
+github.com/honeycombio/libhoney-go v1.9.2 h1:fd5bSpnVB30hKI1pUCWRK/5UhipUK8DYnR8YsDM57VA=
+github.com/honeycombio/libhoney-go v1.9.2/go.mod h1:jdLxh51fcBTy6XIpx1efuJmHePs2xUfVkw25lr+hsmg=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe h1:CHRGQ8V7OlCYtwaKPJi3iA7J+YdNKdo8j7nG5IgDhjs=

--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func main() {
 			MaxConcurrentBatches: libhoney.DefaultMaxConcurrentBatches,
 			PendingWorkCapacity:  libhoney.DefaultPendingWorkCapacity,
 			UserAgentAddition:    userAgentAddition,
-			Transport:            upstreamTransport,
+			Transport:            peerTransport,
 			// gzip compression is expensive, and peers are most likely close to each other
 			// so we can turn off gzip when forwarding to peers
 			DisableGzipCompression: true,

--- a/route/proxy.go
+++ b/route/proxy.go
@@ -43,7 +43,7 @@ func (r *Router) proxy(w http.ResponseWriter, req *http.Request) {
 		upstreamReq.Header.Set("X-Forwarded-For", req.RemoteAddr)
 	}
 	// call the upstream service
-	resp, err := r.HTTPClient.Do(upstreamReq)
+	resp, err := r.proxyClient.Do(upstreamReq)
 	if err != nil {
 		r.handlerReturnWithError(w, ErrUpstreamUnavailable, err)
 		return

--- a/vendor/github.com/honeycombio/libhoney-go/libhoney.go
+++ b/vendor/github.com/honeycombio/libhoney-go/libhoney.go
@@ -33,7 +33,7 @@ const (
 	defaultSampleRate = 1
 	defaultAPIHost    = "https://api.honeycomb.io/"
 	defaultDataset    = "libhoney-go dataset"
-	version           = "1.9.1"
+	version           = "1.9.2"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50

--- a/vendor/github.com/honeycombio/libhoney-go/transmission/transmission.go
+++ b/vendor/github.com/honeycombio/libhoney-go/transmission/transmission.go
@@ -58,6 +58,9 @@ type Honeycomb struct {
 }
 
 func (h *Honeycomb) Start() error {
+	if h.Logger == nil {
+		h.Logger = &nullLogger{}
+	}
 	h.Logger.Printf("default transmission starting")
 	h.responses = make(chan Response, h.PendingWorkCapacity*2)
 	h.muster.MaxBatchSize = h.MaxBatchSize

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -23,7 +23,7 @@ github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
 # github.com/honeycombio/dynsampler-go v0.0.0-20171107180038-7f9929d9ca1f
 github.com/honeycombio/dynsampler-go
-# github.com/honeycombio/libhoney-go v1.9.1
+# github.com/honeycombio/libhoney-go v1.9.2
 github.com/honeycombio/libhoney-go
 github.com/honeycombio/libhoney-go/transmission
 # github.com/jessevdk/go-flags v1.4.0


### PR DESCRIPTION
We want to separate the transmission queue for different communication channels so that one will not affect the other. This creates separate clients for upstream and peer communications. In addition, we disable gzip compression when forwarding events to peers, to hopefully cut down on CPU usage.