### PR TITLE
read response queues, print errored responses

### DIFF
--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -116,9 +116,9 @@ func (h *HoneycombLogger) readResponses() {
 		// read response, log if there's an error
 		switch {
 		case resp.Err != nil:
-			fmt.Printf("Honeycomb Logger got an error back from Honeycomb while trying to send a log line: %s, error: %s, body: %s\n", respString, resp.Err.Error(), string(resp.Body))
+			fmt.Fprintf(os.Stderr, "Honeycomb Logger got an error back from Honeycomb while trying to send a log line: %s, error: %s, body: %s\n", respString, resp.Err.Error(), string(resp.Body))
 		case resp.StatusCode > 202:
-			fmt.Printf("Honeycomb Logger got an unexpected status code back from Honeycomb while trying to send a log line: %s, %s\n", respString, string(resp.Body))
+			fmt.Fprintf(os.Stderr, "Honeycomb Logger got an unexpected status code back from Honeycomb while trying to send a log line: %s, %s\n", respString, string(resp.Body))
 		}
 	}
 }

--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -99,10 +99,28 @@ func (h *HoneycombLogger) Start() error {
 
 	h.builder = h.libhClient.NewBuilder()
 
+	// listen for responses from honeycomb, log to STDOUT if something unusual
+	// comes back
+	go h.readResponses()
+
 	// listen for config reloads
 	h.Config.RegisterReloadCallback(h.reloadBuilder)
 
 	return nil
+}
+
+func (h *HoneycombLogger) readResponses() {
+	resps := h.libhClient.TxResponses()
+	for resp := range resps {
+		respString := fmt.Sprintf("Response: status: %d, duration: %dms", resp.StatusCode, resp.Duration)
+		// read response, log if there's an error
+		switch {
+		case resp.Err != nil:
+			fmt.Printf("Honeycomb Logger got an error back from Honeycomb while trying to send a log line: %s, error: %s, body: %s\n", respString, resp.Err.Error(), string(resp.Body))
+		case resp.StatusCode > 202:
+			fmt.Printf("Honeycomb Logger got an unexpected status code back from Honeycomb while trying to send a log line: %s, %s\n", respString, string(resp.Body))
+		}
+	}
 }
 
 func (h *HoneycombLogger) reloadBuilder() {

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/honeycombio/samproxy/sample"
 	"github.com/honeycombio/samproxy/sharder"
 	"github.com/honeycombio/samproxy/transmit"
+	"github.com/honeycombio/samproxy/types"
 )
 
 // set by travis.
@@ -169,9 +170,9 @@ func main() {
 // readResponses reads the responses from the libhoney responses queue and logs
 // any errors that come down it
 func readResponses(libhC *libhoney.Client, lgr logger.Logger, metricsr metrics.Metrics) {
-	metricsr.Register(fmt.Sprintf("libhoney_transmit_failure.%s", event.TargetUnknown), "counter")
-	metricsr.Register(fmt.Sprintf("libhoney_transmit_failure.%s", event.TargetPeer), "counter")
-	metricsr.Register(fmt.Sprintf("libhoney_transmit_failure.%s", event.TargetUpstream), "counter")
+	metricsr.Register(fmt.Sprintf("libhoney_transmit_failure.%s", types.TargetUnknown), "counter")
+	metricsr.Register(fmt.Sprintf("libhoney_transmit_failure.%s", types.TargetPeer), "counter")
+	metricsr.Register(fmt.Sprintf("libhoney_transmit_failure.%s", types.TargetUpstream), "counter")
 	resps := libhC.TxResponses()
 	for resp := range resps {
 		if resp.Err != nil || resp.StatusCode > 202 {
@@ -191,7 +192,7 @@ func readResponses(libhC *libhoney.Client, lgr logger.Logger, metricsr metrics.M
 				})
 				metricsr.IncrementCounter(fmt.Sprintf("libhoney_transmit_failure.%s", evDetail["target"]))
 			} else {
-				metricsr.IncrementCounter(fmt.Sprintf("libhoney_transmit_failure.%s", event.TargetUnknown))
+				metricsr.IncrementCounter(fmt.Sprintf("libhoney_transmit_failure.%s", types.TargetUnknown))
 			}
 			// read response, log if there's an error
 			switch {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -8,6 +8,7 @@ import (
 )
 
 type Metrics interface {
+	// Register declares a metric; metricType should be one of counter, gauge, histogram
 	Register(name string, metricType string)
 	IncrementCounter(name string)
 	Gauge(name string, val float64)

--- a/route/route.go
+++ b/route/route.go
@@ -119,6 +119,8 @@ func (r *Router) event(w http.ResponseWriter, req *http.Request) {
 			r.handlerReturnWithError(w, ErrReqToEvent, err)
 			return
 		}
+		ev.Type = types.EventTypeEvent
+		ev.Target = types.TargetUpstream
 		logger.WithFields(map[string]interface{}{
 			"api_host": ev.APIHost,
 			"dataset":  ev.Dataset,
@@ -137,6 +139,8 @@ func (r *Router) event(w http.ResponseWriter, req *http.Request) {
 			r.handlerReturnWithError(w, ErrReqToEvent, err)
 			return
 		}
+		ev.Type = types.EventTypeSpan
+		ev.Target = types.TargetPeer
 		ev.APIHost = targetShard.GetAddress()
 		logger.WithFields(map[string]interface{}{
 			"api_host": ev.APIHost,
@@ -153,6 +157,8 @@ func (r *Router) event(w http.ResponseWriter, req *http.Request) {
 		r.handlerReturnWithError(w, ErrReqToEvent, err)
 		return
 	}
+	ev.Type = types.EventTypeSpan
+	ev.Target = types.TargetUpstream
 	span := &types.Span{
 		Event:   *ev,
 		TraceID: trEv.TraceID,

--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -75,6 +75,8 @@ func (d *DefaultTransmission) EnqueueEvent(ev *types.Event) {
 		"request_id": ev.Context.Value(types.RequestIDContextKey{}),
 		"api_host":   ev.APIHost,
 		"dataset":    ev.Dataset,
+		"type":       ev.Type,
+		"target":     ev.Target,
 	}).Debugf("transmit sending event")
 	libhEv := d.builder.NewEvent()
 	libhEv.APIHost = ev.APIHost
@@ -83,6 +85,8 @@ func (d *DefaultTransmission) EnqueueEvent(ev *types.Event) {
 	libhEv.SampleRate = ev.SampleRate
 	libhEv.Timestamp = ev.Timestamp
 	libhEv.Metadata = map[string]string{
+		"type":     ev.Type.String(),
+		"target":   ev.Target.String(),
 		"api_host": ev.APIHost,
 		"dataset":  ev.Dataset,
 	}
@@ -99,6 +103,8 @@ func (d *DefaultTransmission) EnqueueEvent(ev *types.Event) {
 			"request_id": ev.Context.Value(types.RequestIDContextKey{}),
 			"dataset":    ev.Dataset,
 			"api_host":   ev.APIHost,
+			"type":       ev.Type.String(),
+			"target":     ev.Target.String(),
 		}).Errorf("failed to enqueue event")
 	}
 }

--- a/types/event.go
+++ b/types/event.go
@@ -20,9 +20,51 @@ type RequestIDContextKey struct{}
 
 var TraceAlreadySent = errors.New("Can't add span; trace has already been sent.")
 
+type EventType int
+
+const (
+	EventTypeUnknown EventType = iota
+	EventTypeSpan
+	EventTypeEvent
+)
+
+func (et EventType) String() string {
+	switch et {
+	case EventTypeUnknown:
+		return "unknown"
+	case EventTypeSpan:
+		return "span"
+	case EventTypeEvent:
+		return "event"
+	}
+	return "unknown_event_type"
+}
+
+type TargetType int
+
+const (
+	TargetUnknown TargetType = iota
+	TargetPeer
+	TargetUpstream
+)
+
+func (tt TargetType) String() string {
+	switch tt {
+	case TargetUnknown:
+		return "unknown"
+	case TargetPeer:
+		return "peer"
+	case TargetUpstream:
+		return "upstream"
+	}
+	return "unknown_target_type"
+}
+
 // event is not part of a trace - it's an event that showed up with no trace ID
 type Event struct {
 	Context    context.Context
+	Type       EventType
+	Target     TargetType
 	APIHost    string
 	APIKey     string
 	Dataset    string


### PR DESCRIPTION
It'd be nice to know when the place we're sending things hands back errors, whether the things being sent be events, spans, logs, or metrics, and whether we're sending them to peers or upstream to Honeycomb itself. This change teaches samproxy to read the responses queue and do things with errors it gets back down that queue.