### PR TITLE
put a buffered channel in between accepting spans and navigating the internal data structures to avoid blocking the client

### DIFF
--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -50,6 +50,9 @@ func TestAddRootSpan(t *testing.T) {
 	assert.NoError(t, err, "lru cache should start")
 	coll.sentTraceCache = stc
 
+	coll.incoming = make(chan *types.Span, 5)
+	go coll.collect()
+
 	var traceID = "mytrace"
 
 	span := &types.Span{
@@ -66,6 +69,7 @@ func TestAddRootSpan(t *testing.T) {
 	assert.Equal(t, traceID, coll.Cache.Get(traceID).TraceID, "after adding the span, we should have a trace in the cache with the right trace ID")
 	assert.Equal(t, 1, len(transmission.Events), "adding a root span should send the span")
 	assert.Equal(t, "aoeu", transmission.Events[0].Dataset, "sending a root span should immediately send that span via transmission")
+	coll.Stop()
 }
 
 // TestAddSpan tests that adding a span winds up with a trace object in the
@@ -100,6 +104,9 @@ func TestAddSpan(t *testing.T) {
 	stc, err := lru.New(15)
 	assert.NoError(t, err, "lru cache should start")
 	coll.sentTraceCache = stc
+
+	coll.incoming = make(chan *types.Span, 5)
+	go coll.collect()
 
 	var traceID = "mytrace"
 

--- a/config.toml
+++ b/config.toml
@@ -30,7 +30,7 @@ APIKeys = [
 # Eligible for live reload.
 Peers = [
 	"http://127.0.0.1:8080",
-	"http://127.0.0.1:8081",
+	# "http://127.0.0.1:8081",
 	# "http://10.1.2.3.4:8080",
 	# "http://samproxy-1231:8080",
 	# "http://peer-3.fqdn" // assumes port 80
@@ -136,7 +136,7 @@ CacheCapacity = 1000
 		# will keep 1 out of every 30 traces. The choice on whether to keep any specific
 		# trace is random, so the rate is approximate.
 		# Eligible for live reload.
-		SampleRate = 2
+		SampleRate = 1
 
 	[SamplerConfig.dataset1]
 


### PR DESCRIPTION
There are a bunch of locks involved in getting a span into the right in-memory data structure representing a trace. Previously, the client sending us a span or a batch of spans must wait for all the internal bookkeeping to finish before it gets its response. This can be slow and, especially when dealing with a peer to peer transmission, cause thundering herd backups. Separating receipt of the span with the internal bookkeeping via a buffered channel will allow the recipient to spread out the load with the channel accepting the expected ebb and flow of traffic.