### PR TITLE
single thread the collector, remove all the collector's locks

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -292,6 +292,9 @@ func (i *InMemCollector) sendAfterTraceTimeout(trace *types.Trace) {
 // X seconds" this function will cancel all outstanding send timers and start a
 // new one. To prevent infinitely postponed traces, there is still the (TODO)
 // total number of spans cap and a (TODO) gloabal time since first seen cap.
+//
+// TODO this is not yet actually implemented, but leaving the function here as a
+// reminder that it'd be an interesting config to add.
 func (i *InMemCollector) sendAfterIdleTimeout(trace *types.Trace) {
 	// cancel all outstanding sending timers
 	close(trace.CancelSending)

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -51,6 +51,7 @@ func TestAddRootSpan(t *testing.T) {
 	coll.sentTraceCache = stc
 
 	coll.incoming = make(chan *types.Span, 5)
+	coll.toSend = make(chan *sendSignal, 5)
 	go coll.collect()
 
 	var traceID = "mytrace"
@@ -106,6 +107,7 @@ func TestAddSpan(t *testing.T) {
 	coll.sentTraceCache = stc
 
 	coll.incoming = make(chan *types.Span, 5)
+	coll.toSend = make(chan *sendSignal, 5)
 	go coll.collect()
 
 	var traceID = "mytrace"

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/honeycombio/libhoney-go"
+	libhoney "github.com/honeycombio/libhoney-go"
 
 	toml "github.com/pelletier/go-toml"
 )
@@ -48,6 +48,12 @@ type Config interface {
 	// not complete. This should be longer than the longest expected trace
 	// duration.
 	GetTraceTimeout() (int, error)
+
+	// GetSpanSeenDelay is a timer that bumps out sending the trace every time a
+	// span is received. This one is used if you have traces of widely variable
+	// duration, but don't want them to get sent until all spans arrive. Use with
+	// care - if a trace continues to accumulate spans it may never get sent.
+	GetSpanSeenDelay() (int, error)
 
 	// GetOtherConfig attempts to fill the passed in struct with the contents of
 	// a subsection of the config.   This is used by optional configurations to
@@ -101,6 +107,7 @@ type confContents struct {
 	Sampler              string
 	Metrics              string
 	SendDelay            int
+	SpanSeenDelay        int
 	TraceTimeout         int
 	UpstreamBufferSize   int
 	PeerBufferSize       int
@@ -205,6 +212,10 @@ func (f *FileConfig) GetSendDelay() (int, error) {
 	return f.conf.SendDelay, nil
 }
 
+func (f *FileConfig) GetSpanSeenDelay() (int, error) {
+	return f.conf.SpanSeenDelay, nil
+}
+
 func (f *FileConfig) GetTraceTimeout() (int, error) {
 	return f.conf.TraceTimeout, nil
 }
@@ -257,6 +268,8 @@ type MockConfig struct {
 	GetMetricsTypeVal        string
 	GetSendDelayErr          error
 	GetSendDelayVal          int
+	GetSpanSeenDelayErr      error
+	GetSpanSeenDelayVal      int
 	GetTraceTimeoutErr       error
 	GetTraceTimeoutVal       int
 	GetUpstreamBufferSizeVal int
@@ -290,6 +303,7 @@ func (m *MockConfig) GetDefaultSamplerType() (string, error) {
 }
 func (m *MockConfig) GetMetricsType() (string, error) { return m.GetMetricsTypeVal, m.GetMetricsTypeErr }
 func (m *MockConfig) GetSendDelay() (int, error)      { return m.GetSendDelayVal, m.GetSendDelayErr }
+func (m *MockConfig) GetSpanSeenDelay() (int, error)  { return m.GetSpanSeenDelayVal, m.GetSpanSeenDelayErr }
 func (m *MockConfig) GetTraceTimeout() (int, error)   { return m.GetTraceTimeoutVal, m.GetTraceTimeoutErr }
 
 // TODO: allow per-dataset mock values


### PR DESCRIPTION
When used with the dynamic sampler and heavy load, the previous version of samproxy exhibited a thundering herd kind of behavior where a bunch of spans would get sent and then everything would lock up for a while. I believe one cause is all the locks that were scattered through the collector, the collector's cache, and the trace object.

This change removes all those locks by single threading the collector and using channels to serialize all activity. The collector is the thing that
* inserts spans into traces
* calls out to the dynamic sampler to make a sampling decision
* hands off spans to the transmission to be sent

The timeouts (the biggest reason for concurrent access to all the trace objects) are now handled by a goroutine that waits and then submits the trace for sending by adding it to another channel. The main collect entry point reads from the incoming span channel _and_ the ready-to-be-sent trace channel, dealing with them as they come in.

Single threading the collector removed 5 locks. Curious to try it out and see what happens.