### PR TITLE
preferentially process peer traffic to allow upstream backpressure without interal traffic jams

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -15,11 +15,12 @@ import (
 )
 
 type App struct {
-	Config    config.Config     `inject:""`
-	Logger    logger.Logger     `inject:""`
-	Router    route.Router      `inject:"inline"`
-	Collector collect.Collector `inject:""`
-	Metrics   metrics.Metrics   `inject:""`
+	Config         config.Config     `inject:""`
+	Logger         logger.Logger     `inject:""`
+	IncomingRouter route.Router      `inject:"inline"`
+	PeerRouter     route.Router      `inject:"inline"`
+	Collector      collect.Collector `inject:""`
+	Metrics        metrics.Metrics   `inject:""`
 }
 
 // Start on the App obect should block until the proxy is shutting down. After
@@ -44,9 +45,10 @@ func (a *App) Start() error {
 		return err
 	}
 
-	// launch our main router to listen for incoming event traffic
-	go a.Router.LnS("incoming")
-	go a.Router.LnS("peer")
+	// launch our main routers to listen for incoming event traffic from both peers
+	// and external sources
+	go a.IncomingRouter.LnS("incoming")
+	go a.PeerRouter.LnS("peer")
 
 	// block on our signal handler to exit
 	sig := <-sigsToExit

--- a/app/app.go
+++ b/app/app.go
@@ -45,7 +45,8 @@ func (a *App) Start() error {
 	}
 
 	// launch our main router to listen for incoming event traffic
-	go a.Router.LnS()
+	go a.Router.LnS("incoming")
+	go a.Router.LnS("peer")
 
 	// block on our signal handler to exit
 	sig := <-sigsToExit

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -51,6 +51,7 @@ func TestAddRootSpan(t *testing.T) {
 	coll.sentTraceCache = stc
 
 	coll.incoming = make(chan *types.Span, 5)
+	coll.fromPeer = make(chan *types.Span, 5)
 	coll.toSend = make(chan *sendSignal, 5)
 	go coll.collect()
 

--- a/config.toml
+++ b/config.toml
@@ -29,13 +29,14 @@ APIKeys = [
 	"*",                   # wildcard accept all keys
 	]
 
-# Peers is the list of other servers participating in this proxy cluster. Events
+# Peers is the list of all servers participating in this proxy cluster. Events
 # will be sharded evenly across all peers based on the Trace ID. Values here
 # should be the base URL used to access the peer, and should include scheme,
-# hostname (or ip address) and port (if it's non-standard).
+# hostname (or ip address) and port (if it's non-standard). All servers in the
+# cluster should be in this list, including this host.
 # Eligible for live reload.
 Peers = [
-	"http://127.0.0.1:8080",
+	"http://127.0.0.1:8081",
 	# "http://127.0.0.1:8081",
 	# "http://10.1.2.3.4:8080",
 	# "http://samproxy-1231:8080",

--- a/config.toml
+++ b/config.toml
@@ -8,6 +8,12 @@
 # Not eligible for live reload.
 ListenAddr = "0.0.0.0:8080"
 
+# PeerListenAddr is the IP and port on which to listen for traffic being
+# rerouted from a peer. Peer traffic is expected to be HTTP, so if using SSL
+# put something like nginx in front to do the decryption. Not eligible for live
+# reload.
+PeerListenAddr = "0.0.0.0:8081"
+
 # APIKeys is a list of Honeycomb API keys that the proxy will accept. This list
 # only applies to events - other Honeycomb API actions will fall through to the
 # upstream API directly.

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,10 @@ type Config interface {
 	// incoming events
 	GetListenAddr() (string, error)
 
+	// GetPeerListenAddr returns the address and port on which to listen for
+	// peer traffic
+	GetPeerListenAddr() (string, error)
+
 	// GetAPIKeys returns a list of Honeycomb API keys
 	GetAPIKeys() ([]string, error)
 
@@ -97,6 +101,7 @@ type FileConfig struct {
 
 type confContents struct {
 	ListenAddr           string
+	PeerListenAddr       string
 	APIKeys              []string
 	Peers                []string
 	HoneycombAPI         string
@@ -160,6 +165,10 @@ func (f *FileConfig) RegisterReloadCallback(cb func()) {
 
 func (f *FileConfig) GetListenAddr() (string, error) {
 	return f.conf.ListenAddr, nil
+}
+
+func (f *FileConfig) GetPeerListenAddr() (string, error) {
+	return f.conf.PeerListenAddr, nil
 }
 
 func (f *FileConfig) GetAPIKeys() ([]string, error) {
@@ -245,19 +254,21 @@ func (f *FileConfig) GetPeerBufferSize() int {
 // MockConfig will respond with whatever config it's set to do during
 // initialization
 type MockConfig struct {
-	GetAPIKeysErr       error
-	GetAPIKeysVal       []string
-	GetCollectorTypeErr error
-	GetCollectorTypeVal string
-	GetHoneycombAPIErr  error
-	GetHoneycombAPIVal  string
-	GetListenAddrErr    error
-	GetListenAddrVal    string
-	GetLoggerTypeErr    error
-	GetLoggerTypeVal    string
-	GetLoggingLevelErr  error
-	GetLoggingLevelVal  string
-	GetOtherConfigErr   error
+	GetAPIKeysErr        error
+	GetAPIKeysVal        []string
+	GetCollectorTypeErr  error
+	GetCollectorTypeVal  string
+	GetHoneycombAPIErr   error
+	GetHoneycombAPIVal   string
+	GetListenAddrErr     error
+	GetListenAddrVal     string
+	GetPeerListenAddrErr error
+	GetPeerListenAddrVal string
+	GetLoggerTypeErr     error
+	GetLoggerTypeVal     string
+	GetLoggingLevelErr   error
+	GetLoggingLevelVal   string
+	GetOtherConfigErr    error
 	// GetOtherConfigVal must be a JSON representation of the config struct to be populated.
 	GetOtherConfigVal        string
 	GetPeersErr              error
@@ -286,6 +297,9 @@ func (m *MockConfig) GetHoneycombAPI() (string, error) {
 	return m.GetHoneycombAPIVal, m.GetHoneycombAPIErr
 }
 func (m *MockConfig) GetListenAddr() (string, error) { return m.GetListenAddrVal, m.GetListenAddrErr }
+func (m *MockConfig) GetPeerListenAddr() (string, error) {
+	return m.GetPeerListenAddrVal, m.GetPeerListenAddrErr
+}
 func (m *MockConfig) GetLoggerType() (string, error) { return m.GetLoggerTypeVal, m.GetLoggerTypeErr }
 func (m *MockConfig) GetLoggingLevel() (string, error) {
 	return m.GetLoggingLevelVal, m.GetLoggingLevelErr
@@ -303,8 +317,10 @@ func (m *MockConfig) GetDefaultSamplerType() (string, error) {
 }
 func (m *MockConfig) GetMetricsType() (string, error) { return m.GetMetricsTypeVal, m.GetMetricsTypeErr }
 func (m *MockConfig) GetSendDelay() (int, error)      { return m.GetSendDelayVal, m.GetSendDelayErr }
-func (m *MockConfig) GetSpanSeenDelay() (int, error)  { return m.GetSpanSeenDelayVal, m.GetSpanSeenDelayErr }
-func (m *MockConfig) GetTraceTimeout() (int, error)   { return m.GetTraceTimeoutVal, m.GetTraceTimeoutErr }
+func (m *MockConfig) GetSpanSeenDelay() (int, error) {
+	return m.GetSpanSeenDelayVal, m.GetSpanSeenDelayErr
+}
+func (m *MockConfig) GetTraceTimeout() (int, error) { return m.GetTraceTimeoutVal, m.GetTraceTimeoutErr }
 
 // TODO: allow per-dataset mock values
 func (m *MockConfig) GetSamplerTypeForDataset(dataset string) (string, error) {

--- a/route/proxy.go
+++ b/route/proxy.go
@@ -9,9 +9,10 @@ import (
 )
 
 // proxy will pass the request through to Honeycomb unchanged and relay the
-// response, blocking until it gets one.
+// response, blocking until it gets one. This is used for all non-event traffic
+// (eg team api key verification, markers, etc.)
 func (r *Router) proxy(w http.ResponseWriter, req *http.Request) {
-	r.Metrics.IncrementCounter("router_proxied")
+	r.Metrics.IncrementCounter(r.incomingOrPeer + "_router_proxied")
 	r.Logger.Debugf("proxying request for %s", req.URL.Path)
 	upstreamTarget, err := r.Config.GetHoneycombAPI()
 	if err != nil {

--- a/route/route.go
+++ b/route/route.go
@@ -45,6 +45,10 @@ type BatchResponse struct {
 	Error  string `json:"error,omitempty"`
 }
 
+// LnS spins up the Listen and Serve portion of the router. A router is
+// initialized as being for either incoming traffic from clients or traffic from
+// a peer. They listen on different addresses so peer traffic can be
+// prioritized.
 func (r *Router) LnS(incomingOrPeer string) {
 	r.incomingOrPeer = incomingOrPeer
 
@@ -53,11 +57,11 @@ func (r *Router) LnS(incomingOrPeer string) {
 		Transport: r.HTTPTransport,
 	}
 
-	r.Metrics.Register("router_proxied", "counter")
-	r.Metrics.Register("router_event", "counter")
-	r.Metrics.Register("router_batch", "counter")
-	r.Metrics.Register("router_span", "counter")
-	r.Metrics.Register("router_peer", "counter")
+	r.Metrics.Register(r.incomingOrPeer+"_router_proxied", "counter")
+	r.Metrics.Register(r.incomingOrPeer+"_router_event", "counter")
+	r.Metrics.Register(r.incomingOrPeer+"_router_batch", "counter")
+	r.Metrics.Register(r.incomingOrPeer+"_router_span", "counter")
+	r.Metrics.Register(r.incomingOrPeer+"_router_peer", "counter")
 
 	muxxer := mux.NewRouter()
 
@@ -129,7 +133,7 @@ func (r *Router) event(w http.ResponseWriter, req *http.Request) {
 
 	// not part of a trace. send along upstream
 	if trEv.TraceID == "" {
-		r.Metrics.IncrementCounter("router_event")
+		r.Metrics.IncrementCounter(r.incomingOrPeer + "_router_event")
 		ev, err := r.requestToEvent(req, reqBod)
 		if err != nil {
 			r.handlerReturnWithError(w, ErrReqToEvent, err)
@@ -149,7 +153,8 @@ func (r *Router) event(w http.ResponseWriter, req *http.Request) {
 	// peer
 	targetShard := r.Sharder.WhichShard(trEv.TraceID)
 	if !targetShard.Equals(r.Sharder.MyShard()) {
-		r.Metrics.IncrementCounter("router_peer")
+		// it's not for us; send to the peer
+		r.Metrics.IncrementCounter(r.incomingOrPeer + "_router_peer")
 		ev, err := r.requestToEvent(req, reqBod)
 		if err != nil {
 			r.handlerReturnWithError(w, ErrReqToEvent, err)
@@ -179,7 +184,7 @@ func (r *Router) event(w http.ResponseWriter, req *http.Request) {
 		Event:   *ev,
 		TraceID: trEv.TraceID,
 	}
-	r.Metrics.IncrementCounter("router_span")
+	r.Metrics.IncrementCounter(r.incomingOrPeer + "_router_span")
 	logger.WithFields(map[string]interface{}{
 		"api_host": ev.APIHost,
 		"dataset":  ev.Dataset,
@@ -250,7 +255,7 @@ func (r *Router) requestToEvent(req *http.Request, reqBod []byte) (*types.Event,
 }
 
 func (r *Router) batch(w http.ResponseWriter, req *http.Request) {
-	r.Metrics.IncrementCounter("router_batch")
+	r.Metrics.IncrementCounter(r.incomingOrPeer + "_router_batch")
 	defer req.Body.Close()
 	bodyReader, err := getMaybeGzippedBody(req)
 	if err != nil {
@@ -285,7 +290,7 @@ func (r *Router) batch(w http.ResponseWriter, req *http.Request) {
 		}
 		if traceID == "" {
 			// not part of a trace. send along upstream
-			r.Metrics.IncrementCounter("router_event")
+			r.Metrics.IncrementCounter(r.incomingOrPeer + "_router_event")
 			ev, err := r.batchedEventToEvent(req, bev)
 			if err != nil {
 				batchedResponses = append(
@@ -312,7 +317,7 @@ func (r *Router) batch(w http.ResponseWriter, req *http.Request) {
 		// ok, we're a span. Figure out if we should handle locally or pass on to a peer
 		targetShard := r.Sharder.WhichShard(traceID)
 		if !targetShard.Equals(r.Sharder.MyShard()) {
-			r.Metrics.IncrementCounter("router_peer")
+			r.Metrics.IncrementCounter(r.incomingOrPeer + "_router_peer")
 			ev, err := r.batchedEventToEvent(req, bev)
 			if err != nil {
 				batchedResponses = append(
@@ -355,7 +360,7 @@ func (r *Router) batch(w http.ResponseWriter, req *http.Request) {
 			Event:   *ev,
 			TraceID: traceID,
 		}
-		r.Metrics.IncrementCounter("router_span")
+		r.Metrics.IncrementCounter(r.incomingOrPeer + "_router_span")
 		logger.WithFields(map[string]interface{}{
 			"api_host": ev.APIHost,
 			"dataset":  ev.Dataset,

--- a/sharder/deterministic.go
+++ b/sharder/deterministic.go
@@ -78,7 +78,8 @@ func (d *DeterministicSharder) Start() error {
 	}
 
 	// go through peer list, resolve each address, see if any of them match any
-	// local interface
+	// local interface. Note that this assumes only one instance of samproxy per
+	// host can run.
 	var selfIndexIntoPeerList int
 	var found bool
 	for i, peerShard := range d.peers {

--- a/transmit/mock.go
+++ b/transmit/mock.go
@@ -1,6 +1,8 @@
 package transmit
 
-import "github.com/honeycombio/samproxy/types"
+import (
+	"github.com/honeycombio/samproxy/types"
+)
 
 type MockTransmission struct {
 	Events []*types.Event


### PR DESCRIPTION
This PR implements an idea: by preferentially processing spans coming from peers over spans coming from the thing actually sending Samproxy data, we'll ensure that when confronting situations where we can't process all the spans fast enough, we don't make the problem worse while trying to work through the backlog of already-accepted traffic. 