### PR TITLE
Adding debug logging, error handling, timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
             - checkout
             - buildevents/berun:
                 bename: go_build
-                becommand: go install -ldflags "-X main.Version=${CIRCLE_TAG:1:20}" ./...
+                becommand: go install -ldflags "-X main.BuildID=${CIRCLE_TAG:1:20}" ./...
             - buildevents/berun:
                 bename: apt_get_update
                 becommand: sudo apt-get -qq update

--- a/cmd/samproxy/main.go
+++ b/cmd/samproxy/main.go
@@ -37,6 +37,7 @@ type Options struct {
 }
 
 func main() {
+	fmt.Println("Starting samproxy")
 	var opts Options
 	flagParser := flag.NewParser(&opts, flag.Default)
 	if extraArgs, err := flagParser.Parse(); err != nil || len(extraArgs) != 0 {
@@ -47,7 +48,7 @@ func main() {
 	if BuildID == "" {
 		version = "dev"
 	} else {
-		version = "0." + BuildID
+		version = BuildID
 	}
 
 	if opts.Version {

--- a/cmd/samproxy/main.go
+++ b/cmd/samproxy/main.go
@@ -37,7 +37,6 @@ type Options struct {
 }
 
 func main() {
-	fmt.Println("Starting samproxy")
 	var opts Options
 	flagParser := flag.NewParser(&opts, flag.Default)
 	if extraArgs, err := flagParser.Parse(); err != nil || len(extraArgs) != 0 {

--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"github.com/honeycombio/samproxy/logger"
 	"github.com/honeycombio/samproxy/metrics"
 	"github.com/honeycombio/samproxy/types"
 )
@@ -22,6 +23,7 @@ type Cache interface {
 type DefaultInMemCache struct {
 	Config  CacheConfig
 	Metrics metrics.Metrics
+	Logger  logger.Logger
 
 	cache map[string]*types.Trace
 
@@ -38,6 +40,8 @@ type CacheConfig struct {
 const DefaultInMemCacheCapacity = 10000
 
 func (d *DefaultInMemCache) Start() error {
+	d.Logger.Debugf("Starting DefaultInMemCache")
+	defer func() { d.Logger.Debugf("Finished starting DefaultInMemCache") }()
 	if d.Config.CacheCapacity == 0 {
 		d.Config.CacheCapacity = DefaultInMemCacheCapacity
 	}

--- a/collect/cache/cache_test.go
+++ b/collect/cache/cache_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/honeycombio/samproxy/logger"
 	"github.com/honeycombio/samproxy/metrics"
 	"github.com/honeycombio/samproxy/types"
 )
@@ -16,6 +17,7 @@ func TestCacheSetGet(t *testing.T) {
 	c := &DefaultInMemCache{
 		Config:  CacheConfig{10},
 		Metrics: s,
+		Logger:  &logger.NullLogger{},
 	}
 	c.Start()
 
@@ -35,6 +37,7 @@ func TestBufferOverrun(t *testing.T) {
 	c := &DefaultInMemCache{
 		Config:  CacheConfig{2},
 		Metrics: s,
+		Logger:  &logger.NullLogger{},
 	}
 	c.Start()
 

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -80,6 +80,8 @@ type traceSentRecord struct {
 }
 
 func (i *InMemCollector) Start() error {
+	i.Logger.Debugf("Starting InMemCollector")
+	defer func() { i.Logger.Debugf("Finished starting InMemCollector") }()
 	i.defaultSampler = i.SamplerFactory.GetDefaultSamplerImplementation()
 	imcConfig := &imcConfig{}
 	err := i.Config.GetOtherConfig("InMemCollector", imcConfig)
@@ -95,6 +97,7 @@ func (i *InMemCollector) Start() error {
 			CacheCapacity: capacity,
 		},
 		Metrics: i.Metrics,
+		Logger:  i.Logger,
 	}
 	c.Start()
 	i.Cache = c

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -42,6 +42,7 @@ func TestAddRootSpan(t *testing.T) {
 			CacheCapacity: 3,
 		},
 		Metrics: &metrics.NullMetrics{},
+		Logger:  &logger.NullLogger{},
 	}
 	err := c.Start()
 	assert.NoError(t, err, "in-mem cache should start")
@@ -116,6 +117,7 @@ func TestAddSpan(t *testing.T) {
 			CacheCapacity: 3,
 		},
 		Metrics: &metrics.NullMetrics{},
+		Logger:  &logger.NullLogger{},
 	}
 	c.Start()
 	coll.Cache = c

--- a/config/redis.go
+++ b/config/redis.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/garyburd/redigo/redis"
+	"github.com/sirupsen/logrus"
 
 	"github.com/honeycombio/samproxy/config/redimem"
 )
@@ -112,7 +113,11 @@ func (rc *RedisPeerFileConfig) Start() error {
 		rc.publicAddr = publicListenAddr
 
 		// register myself once
-		rc.peerStore.Register(context.TODO(), publicListenAddr, peerEntryTimeout)
+		err = rc.peerStore.Register(context.TODO(), publicListenAddr, peerEntryTimeout)
+		if err != nil {
+			logrus.WithError(err).Errorf("failed to register self with peer store")
+			return
+		}
 
 		// go establish a regular registration heartbeat to ensure I stay alive in redis
 		go rc.registerSelf()

--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -105,6 +105,8 @@ func (h *HoneycombLogger) Start() error {
 	// listen for config reloads
 	h.Config.RegisterReloadCallback(h.reloadBuilder)
 
+	fmt.Printf("Starting Honeycomb Logger - see Honeycomb %s dataset for service logs\n", h.loggerConfig.LoggerDataset)
+
 	return nil
 }
 

--- a/metrics/honeycomb.go
+++ b/metrics/honeycomb.go
@@ -66,6 +66,8 @@ type histogram struct {
 }
 
 func (h *HoneycombMetrics) Start() error {
+	h.Logger.Debugf("Starting HoneycombMetrics")
+	defer func() { h.Logger.Debugf("Finished starting HoneycombMetrics") }()
 	mc := MetricsConfig{}
 	err := h.Config.GetOtherConfig("HoneycombMetrics", &mc)
 	if err != nil {

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -9,10 +9,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/honeycombio/samproxy/config"
+	"github.com/honeycombio/samproxy/logger"
 )
 
 type PromMetrics struct {
 	Config config.Config `inject:""`
+	Logger logger.Logger `inject:""`
 	// metrics keeps a record of all the registered metrics so we can increment
 	// them by name
 	metrics map[string]interface{}
@@ -23,6 +25,8 @@ type PromConfig struct {
 }
 
 func (p *PromMetrics) Start() error {
+	p.Logger.Debugf("Starting PromMetrics")
+	defer func() { p.Logger.Debugf("Finished starting PromMetrics") }()
 	pc := PromConfig{}
 	err := p.Config.GetOtherConfig("PrometheusMetrics", &pc)
 	if err != nil {

--- a/route/route.go
+++ b/route/route.go
@@ -108,6 +108,7 @@ func (r *Router) LnS(incomingOrPeer string) {
 }
 
 func (r *Router) alive(w http.ResponseWriter, req *http.Request) {
+	r.Logger.Debugf("answered /x/alive check")
 	w.Write([]byte(`{"source":"samproxy","alive":true}`))
 }
 

--- a/sample/deterministic.go
+++ b/sample/deterministic.go
@@ -28,6 +28,8 @@ type DetSamplerConfig struct {
 }
 
 func (d *DeterministicSampler) Start() error {
+	d.Logger.Debugf("Starting DeterministicSampler")
+	defer func() { d.Logger.Debugf("Finished starting DeterministicSampler") }()
 	if err := d.loadConfigs(); err != nil {
 		return err
 	}

--- a/sample/dynamic.go
+++ b/sample/dynamic.go
@@ -38,6 +38,8 @@ type DynSamplerConfig struct {
 }
 
 func (d *DynamicSampler) Start() error {
+	d.Logger.Debugf("Starting DynamicSampler")
+	defer func() { d.Logger.Debugf("Finished starting DynamicSampler") }()
 	dsConfig := DynSamplerConfig{}
 	configKey := fmt.Sprintf("SamplerConfig.%s", d.configName)
 	err := d.Config.GetOtherConfig(configKey, &dsConfig)

--- a/sharder/deterministic.go
+++ b/sharder/deterministic.go
@@ -149,8 +149,8 @@ func (d *DeterministicSharder) Start() error {
 		if found {
 			break
 		}
-		d.Logger.Debugf("Failed to find self in peer list; waiting 1sec and trying again")
-		time.Sleep(1 * time.Second)
+		d.Logger.Debugf("Failed to find self in peer list; waiting 5sec and trying again")
+		time.Sleep(5 * time.Second)
 	}
 	if !found {
 		d.Logger.Debugf("list of current peers: %+v", d.peers)

--- a/sharder/deterministic.go
+++ b/sharder/deterministic.go
@@ -83,6 +83,8 @@ type DeterministicSharder struct {
 }
 
 func (d *DeterministicSharder) Start() error {
+	d.Logger.Debugf("Starting DeterministicSharder")
+	defer func() { d.Logger.Debugf("Finished starting DeterministicSharder") }()
 
 	d.Config.RegisterReloadCallback(func() {
 		d.Logger.Debugf("reloading deterministic sharder config")

--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -40,6 +40,9 @@ type DefaultTransmission struct {
 }
 
 func (d *DefaultTransmission) Start() error {
+	d.Logger.Debugf("Starting DefaultTransmission: %s type", d.Name)
+	defer func() { d.Logger.Debugf("Finished starting DefaultTransmission: %s type", d.Name) }()
+
 	// upstreamAPI doesn't get set when the client is initialized, because
 	// it can be reloaded from the config file while live
 	upstreamAPI, err := d.Config.GetHoneycombAPI()


### PR DESCRIPTION
* Updating the build to correctly set the version
* adding some output indicating the service is starting always
* adding debug logging indicating each subsystem boots successfully
* adding a timeout to the redis scan to fail when trying to scan too large redis instances
* add indication that registration failed when the initial redis connection fails
