### PR TITLE
add endpoint to allow querying the version of the binary via HTTP

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -21,6 +21,10 @@ type App struct {
 	PeerRouter     route.Router      `inject:"inline"`
 	Collector      collect.Collector `inject:""`
 	Metrics        metrics.Metrics   `inject:""`
+
+	// Version is the build ID for samproxy so that the running process may answer
+	// requests for the version
+	Version string
 }
 
 // Start on the App obect should block until the proxy is shutting down. After
@@ -44,6 +48,9 @@ func (a *App) Start() error {
 		a.Logger.WithField("error", err).Errorf("Failed to validate API key")
 		return err
 	}
+
+	a.IncomingRouter.SetVersion(a.Version)
+	a.PeerRouter.SetVersion(a.Version)
 
 	// launch our main routers to listen for incoming event traffic from both peers
 	// and external sources

--- a/cmd/samproxy/main.go
+++ b/cmd/samproxy/main.go
@@ -71,7 +71,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	a := app.App{}
+	a := app.App{
+		Version: version,
+	}
 
 	// get desired implementation for each dependency to inject
 	lgr := logger.GetLoggerImplementation(c)

--- a/route/route.go
+++ b/route/route.go
@@ -130,7 +130,7 @@ func (r *Router) panic(w http.ResponseWriter, req *http.Request) {
 }
 
 func (r *Router) version(w http.ResponseWriter, req *http.Request) {
-	w.Write([]byte(fmt.Sprintf(`{"source":"samproxy","version":%s}`, r.versionStr)))
+	w.Write([]byte(fmt.Sprintf(`{"source":"samproxy","version":"%s"}`, r.versionStr)))
 }
 
 // event is handler for /1/event/


### PR DESCRIPTION
It is useful to be able to probe the running binary for version info. This endpoint enables that.