### PR TITLE
honor proxy settings in the environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - buildevents/start_trace
 
+  finish_trace:
+    executor: linuxgo
+    steps:
+      - buildevents/watch_build_and_finish
+
   test:
     executor: linuxgo
     steps:
@@ -79,11 +84,6 @@ jobs:
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/samproxy_${CIRCLE_TAG:1:20}_amd64.deb
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/samproxy-${CIRCLE_TAG:1:20}-1.x86_64.rpm
 
-  finish_trace:
-    executor: linuxgo
-    steps:
-      - buildevents/finish_trace:
-          result: success
 
 workflows:
   build:
@@ -92,15 +92,15 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - test:
+      - finish_trace:
           requires:
             - setup
           filters:
             tags:
               only: /.*/
-      - finish_trace:
+      - test:
           requires:
-            - test
+            - setup
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  buildevents: honeycombio/buildevents@0.0.2
+  buildevents: honeycombio/buildevents@0.1.1
 
 executors:
   linuxgo:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,8 @@ jobs:
   finish_trace:
     executor: linuxgo
     steps:
-      - buildevents/watch_build_and_finish
+      - buildevents/finish_trace:
+          success: true
 
   test:
     executor: linuxgo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  buildevents: honeycombio/buildevents@0.1.1
+  buildevents: honeycombio/buildevents@0.0.3
 
 executors:
   linuxgo:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,6 @@ jobs:
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/samproxy_${CIRCLE_TAG:1:20}_amd64.deb
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} ./artifacts/samproxy-${CIRCLE_TAG:1:20}-1.x86_64.rpm
 
-
 workflows:
   build:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - buildevents/start_trace
 
-  finish_trace:
-    executor: linuxgo
-    steps:
-      - buildevents/finish_trace:
-          success: true
+  # finish_trace:
+  #   executor: linuxgo
+  #   steps:
+  #     - buildevents/finish_trace:
+  #         success: true
 
   test:
     executor: linuxgo
@@ -92,12 +92,12 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - finish_trace:
-          requires:
-            - setup
-          filters:
-            tags:
-              only: /.*/
+      # - finish_trace:
+      #     requires:
+      #       - setup
+      #     filters:
+      #       tags:
+      #         only: /.*/
       - test:
           requires:
             - setup

--- a/cmd/samproxy/main.go
+++ b/cmd/samproxy/main.go
@@ -95,6 +95,7 @@ func main() {
 
 	// upstreamTransport is the http transport used to send things on to Honeycomb
 	upstreamTransport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
 			Timeout: 10 * time.Second,
 		}).Dial,
@@ -103,6 +104,7 @@ func main() {
 
 	// peerTransport is the http transport used to send things to a local peer
 	peerTransport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
 			Timeout: 3 * time.Second,
 		}).Dial,


### PR DESCRIPTION
Resolves #44 

The default go http library honors settings from the environment with the built in `ProxyFromEnvironment` function.  This change configures samproxy to use the same thing.

Coming along for the ride is an update to the circle ci config to get the build to run.