### PR TITLE
[router] add zstd support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/honeycombio/samproxy
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/aws/aws-sdk-go v1.28.14 // indirect
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
 	github.com/davecgh/go-spew v1.1.1
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
@@ -20,10 +21,11 @@ require (
 	github.com/honeycombio/dynsampler-go v0.0.0-20171107180038-7f9929d9ca1f
 	github.com/honeycombio/libhoney-go v1.12.2
 	github.com/jessevdk/go-flags v1.4.0
-	github.com/klauspost/compress v1.9.1 // indirect
+	github.com/klauspost/compress v1.9.1
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/pelletier/go-toml v1.2.0
+	github.com/pierrec/lz4 v2.4.1+incompatible // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/prometheus/client_golang v0.9.0
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/aws/aws-sdk-go v1.28.14 h1:ZeFS5GVtsJMZ0TBJ5n4HYwB/4MpY0hWkRthNNZkIzNo=
+github.com/aws/aws-sdk-go v1.28.14/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -40,6 +42,8 @@ github.com/honeycombio/libhoney-go v1.12.2 h1:KA66J2HxOxV8kTEDZ4f9d97KQwb5aTKt7Y
 github.com/honeycombio/libhoney-go v1.12.2/go.mod h1:jdLxh51fcBTy6XIpx1efuJmHePs2xUfVkw25lr+hsmg=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/klauspost/compress v1.9.1 h1:TWy0o9J9c6LK9C8t7Msh6IAJNXbsU/nvKLTQUU5HdaY=
 github.com/klauspost/compress v1.9.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe h1:CHRGQ8V7OlCYtwaKPJi3iA7J+YdNKdo8j7nG5IgDhjs=
@@ -53,6 +57,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pierrec/lz4 v2.4.1+incompatible h1:mFe7ttWaflA46Mhqh+jUfjp2qTbPYxLB2/OyBppH9dg=
+github.com/pierrec/lz4 v2.4.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -1,1 +1,89 @@
 package route
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+func TestDecompression(t *testing.T) {
+	payload := "payload"
+	pReader := strings.NewReader(payload)
+
+	decoders, err := makeDecoders(numZstdDecoders)
+	if err != nil {
+		t.Errorf("unexpected err: %s", err.Error())
+	}
+
+	router := &Router{zstdDecoders: decoders}
+	req := &http.Request{
+		Body:   ioutil.NopCloser(pReader),
+		Header: http.Header{},
+	}
+	reader, err := router.getMaybeCompressedBody(req)
+	if err != nil {
+		t.Errorf("unexpected err: %s", err.Error())
+	}
+
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Errorf("unexpected err: %s", err.Error())
+	}
+	if string(b) != payload {
+		t.Errorf("%s != %s", string(b), payload)
+	}
+
+	buf := &bytes.Buffer{}
+	w := gzip.NewWriter(buf)
+	_, err = w.Write([]byte(payload))
+	if err != nil {
+		t.Errorf("unexpected err: %s", err.Error())
+	}
+	w.Close()
+
+	req.Body = ioutil.NopCloser(buf)
+	req.Header.Set("Content-Encoding", "gzip")
+	reader, err = router.getMaybeCompressedBody(req)
+	if err != nil {
+		t.Errorf("unexpected err: %s", err.Error())
+	}
+
+	b, err = ioutil.ReadAll(reader)
+	if err != nil {
+		t.Errorf("unexpected err: %s", err.Error())
+	}
+	if string(b) != payload {
+		t.Errorf("%s != %s", string(b), payload)
+	}
+
+	buf = &bytes.Buffer{}
+	zstdW, err := zstd.NewWriter(buf)
+	if err != nil {
+		t.Errorf("unexpected err: %s", err.Error())
+	}
+	_, err = zstdW.Write([]byte(payload))
+	if err != nil {
+		t.Errorf("unexpected err: %s", err.Error())
+	}
+	zstdW.Close()
+
+	req.Body = ioutil.NopCloser(buf)
+	req.Header.Set("Content-Encoding", "zstd")
+	reader, err = router.getMaybeCompressedBody(req)
+	if err != nil {
+		t.Errorf("unexpected err: %s", err.Error())
+	}
+
+	b, err = ioutil.ReadAll(reader)
+	if err != nil {
+		t.Errorf("unexpected err: %s", err.Error())
+	}
+	if string(b) != payload {
+		t.Errorf("%s != %s", string(b), payload)
+	}
+}


### PR DESCRIPTION
libhoney-go uses zstd by default, so we should support it.

Drive-by cleanup of possible gzip leak. We used to read the compressed body into a buffer, and then return a gzip reader. Without exposing the Close interface, there was no way to clean up the resources created by the gzip reader. I think this would have lead to OOMs over time.

I copied the zstdReader pooling method from our internal shepherd implementation, as that seems to work well enough.

I smoke tested this with gzip (from python) and zstd (libhoney-go) events to verify everything works.