### PR TITLE
close possible avenue for racing and panic'ing/sending traces multiple times

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -362,30 +362,6 @@ func (i *InMemCollector) sendAfterTraceTimeout(trace *types.Trace) {
 	go i.pauseAndSend(dur, trace)
 }
 
-// if the configuration says "send the trace when no new spans have come in for
-// X seconds" this function will cancel all outstanding send timers and start a
-// new one. To prevent infinitely postponed traces, there is still the (TODO)
-// total number of spans cap and a (TODO) gloabal time since first seen cap.
-//
-// TODO this is not yet actually implemented, but leaving the function here as a
-// reminder that it'd be an interesting config to add.
-func (i *InMemCollector) sendAfterIdleTimeout(trace *types.Trace) {
-	// cancel all outstanding sending timers
-	close(trace.CancelSending)
-
-	// get the configured delay
-	spanSeenDelay, err := i.Config.GetSpanSeenDelay()
-	if err != nil {
-		i.Logger.Errorf("failed to get send delay. pausing for 2 seconds")
-		spanSeenDelay = 2
-	}
-
-	// make a new cancel sending channel and then wait on it
-	trace.CancelSending = make(chan struct{})
-	dur := time.Duration(spanSeenDelay) * time.Second
-	go i.pauseAndSend(dur, trace)
-}
-
 // sendAfterRootDelay waits the SendDelay timeout then registers the trace to be
 // sent.
 func (i *InMemCollector) sendAfterRootDelay(trace *types.Trace) {

--- a/types/event.go
+++ b/types/event.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"sync"
 	"time"
 )
 
@@ -97,6 +98,8 @@ type Trace struct {
 	// waiting a full minute (or whatever the trace timeout is) then doing nothing.
 	// Closing this channel will cause any still-waiting send timers to exit.
 	CancelSending chan struct{}
+
+	SendOnce sync.Once
 
 	// spans is the list of spans in this trace, protected by the list lock
 	spans []*Span


### PR DESCRIPTION
It looks to be (theoretically, I haven't verified by testing it) possible for multiple goroutines to end up in this particular switch arm at the same time.

Use a `sync.Once` to make sure that even if that happens they can't both try to close the channel and/or send the trace.