### PR TITLE
[redis] allow IP and other host identifiers

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -55,6 +55,27 @@ Peers = [
 # Not eligible for live reload.
 RedisHost = "localhost:6379"
 
+# IdentifierInterfaceName is optional. By default, when using RedisHost, samproxy will use
+# the local hostname to identify itself to other peers in Redis. If your environment
+# requires that you use IPs as identifiers (for example, if peers can't resolve eachother
+# by name), you can specify the network interface that samproxy is listening on here.
+# Samproxy will use the fist unicast address that it finds on the specified network
+# interface as its identifier.
+# Not eligible for live reload.
+# IdentifierInterfaceName = "eth0"
+
+# UseIPV6Identifier is optional. If using IdentifierInterfaceName, samproxy will default to the first
+# IPv4 unicast address it finds for the specified interface. If UseIPV6Identifier is used, will use
+# the first IPV6 unicast address found.
+# UseIPV6Identifier = false
+
+# RedisIdentifier is optional. By default, when using RedisHost, samproxy will use
+# the local hostname to identify itself to other peers in Redis. If your environment
+# requires that you use IPs as identifiers (for example, if peers can't resolve eachother
+# by name), you can specify the exact identifier (IP address, etc) to use here.
+# Not eligible for live reload. Overrides IdentifierInterfaceName, if both are set.
+# RedisIdentifier = "192.168.1.1"
+
 # HoneycombAPI is the URL for the upstream Honeycomb API.
 # Eligible for live reload.
 HoneycombAPI = "https://api.honeycomb.io"

--- a/config.toml
+++ b/config.toml
@@ -59,7 +59,7 @@ RedisHost = "localhost:6379"
 # the local hostname to identify itself to other peers in Redis. If your environment
 # requires that you use IPs as identifiers (for example, if peers can't resolve eachother
 # by name), you can specify the network interface that samproxy is listening on here.
-# Samproxy will use the fist unicast address that it finds on the specified network
+# Samproxy will use the first unicast address that it finds on the specified network
 # interface as its identifier.
 # Not eligible for live reload.
 # IdentifierInterfaceName = "eth0"

--- a/config/fileconfig.go
+++ b/config/fileconfig.go
@@ -15,23 +15,26 @@ type FileConfig struct {
 }
 
 type confContents struct {
-	ListenAddr           string
-	PeerListenAddr       string
-	APIKeys              []string
-	Peers                []string
-	RedisHost            string
-	HoneycombAPI         string
-	CollectCacheCapacity int
-	Logger               string
-	LoggingLevel         string
-	Collector            string
-	Sampler              string
-	Metrics              string
-	SendDelay            int
-	SpanSeenDelay        int
-	TraceTimeout         int
-	UpstreamBufferSize   int
-	PeerBufferSize       int
+	ListenAddr              string
+	PeerListenAddr          string
+	APIKeys                 []string
+	Peers                   []string
+	RedisHost               string
+	RedisIdentifier         string
+	IdentifierInterfaceName string
+	UseIPV6Identifier       bool
+	HoneycombAPI            string
+	CollectCacheCapacity    int
+	Logger                  string
+	LoggingLevel            string
+	Collector               string
+	Sampler                 string
+	Metrics                 string
+	SendDelay               int
+	SpanSeenDelay           int
+	TraceTimeout            int
+	UpstreamBufferSize      int
+	PeerBufferSize          int
 }
 
 // Used to marshall in the sampler type in SamplerConfig definitions
@@ -97,6 +100,18 @@ func (f *FileConfig) GetPeers() ([]string, error) {
 
 func (f *FileConfig) GetRedisHost() (string, error) {
 	return f.conf.RedisHost, nil
+}
+
+func (f *FileConfig) GetIdentifierInterfaceName() (string, error) {
+	return f.conf.IdentifierInterfaceName, nil
+}
+
+func (f *FileConfig) GetUseIPV6Identifier() (bool, error) {
+	return f.conf.UseIPV6Identifier, nil
+}
+
+func (f *FileConfig) GetRedisIdentifier() (string, error) {
+	return f.conf.RedisIdentifier, nil
 }
 
 func (f *FileConfig) GetHoneycombAPI() (string, error) {


### PR DESCRIPTION
When using redis for peer resolution, we register the host using its hostname. This doesn't work if peers can't resolve eachother by hostname. This adds two new ways to identify the host in the peer list:

- If IdentifierInterfaceName is set, pulls the first unicast IP address from that interface. By default, we pull the IPV4 address, but UseIPV6Identifier can optionally be set to true to use the IPV6 address
- If RedisIdentifier is set, use whatever value is specified to identify the host. This is sort of a catchall in case our other options don't work.

Tested this locally. Here's the log output from each case:

```
INFO[0000] using identifier from interface               identifier="[fe80::101c:fe8c:b38e:5db8]" interface=en0
```

```
INFO[0000] using identifier from interface               identifier=192.168.1.9 interface=en0
INFO[0000] using specific identifier from config         identifier=192.168.1.1
```