### PR TITLE
sharder: Refuse to reload empty peer list

### DIFF
--- a/config/mock.go
+++ b/config/mock.go
@@ -8,6 +8,7 @@ import (
 // MockConfig will respond with whatever config it's set to do during
 // initialization
 type MockConfig struct {
+	Callbacks            []func()
 	GetAPIKeysErr        error
 	GetAPIKeysVal        []string
 	GetCollectorTypeErr  error
@@ -46,8 +47,14 @@ type MockConfig struct {
 	PeerManagementType       string
 }
 
-func (m *MockConfig) ReloadConfig()                 {}
-func (m *MockConfig) RegisterReloadCallback(func()) {}
+func (m *MockConfig) ReloadConfig() {
+	for _, callback := range m.Callbacks {
+		callback()
+	}
+}
+func (m *MockConfig) RegisterReloadCallback(callback func()) {
+	m.Callbacks = append(m.Callbacks, callback)
+}
 func (m *MockConfig) GetAPIKeys() ([]string, error) { return m.GetAPIKeysVal, m.GetAPIKeysErr }
 func (m *MockConfig) GetCollectorType() (string, error) {
 	return m.GetCollectorTypeVal, m.GetCollectorTypeErr

--- a/sharder/deterministic.go
+++ b/sharder/deterministic.go
@@ -174,6 +174,10 @@ func (d *DeterministicSharder) loadPeerList() error {
 		return errors.Wrap(err, "failed to get peer list config")
 	}
 
+	if len(peerList) == 0 {
+		return errors.New("refusing to load empty peer list")
+	}
+
 	// turn my peer list into a list of shards
 	newPeers := make([]*DetShard, 0, len(peerList))
 	for _, peer := range peerList {

--- a/sharder/deterministic_test.go
+++ b/sharder/deterministic_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/honeycombio/samproxy/config"
+	"github.com/honeycombio/samproxy/internal/peer"
 	"github.com/honeycombio/samproxy/logger"
 	"github.com/stretchr/testify/assert"
 )

--- a/sharder/deterministic_test.go
+++ b/sharder/deterministic_test.go
@@ -1,0 +1,42 @@
+package sharder
+
+import (
+	"testing"
+
+	"github.com/honeycombio/samproxy/config"
+	"github.com/honeycombio/samproxy/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWhichShard(t *testing.T) {
+	const (
+		selfAddr = "127.0.0.1:8081"
+		traceID  = "test"
+	)
+
+	peers := []string{
+		"http://" + selfAddr,
+		"http://2.2.2.2:8081",
+		"http://3.3.3.3:8081",
+	}
+	config := &config.MockConfig{
+		GetPeerListenAddrVal: selfAddr,
+		GetPeersVal:          peers,
+	}
+	sharder := DeterministicSharder{
+		Config: config,
+		Logger: &logger.NullLogger{},
+	}
+
+	assert.NoError(t, sharder.Start(),
+		"starting deterministic sharder should not error")
+
+	shard := sharder.WhichShard(traceID)
+	assert.Contains(t, peers, shard.GetAddress(),
+		"should select a peer for a trace")
+
+	config.GetPeersVal = []string{}
+	config.ReloadConfig()
+	assert.Equal(t, shard.GetAddress(), sharder.WhichShard(traceID).GetAddress(),
+		"should select the same peer if peer list becomes empty")
+}

--- a/sharder/deterministic_test.go
+++ b/sharder/deterministic_test.go
@@ -22,10 +22,14 @@ func TestWhichShard(t *testing.T) {
 	config := &config.MockConfig{
 		GetPeerListenAddrVal: selfAddr,
 		GetPeersVal:          peers,
+		PeerManagementType:   "file",
 	}
+	filePeers, err := peer.NewPeers(config)
+	assert.Equal(t, nil, err)
 	sharder := DeterministicSharder{
 		Config: config,
 		Logger: &logger.NullLogger{},
+		Peers:  filePeers,
 	}
 
 	assert.NoError(t, sharder.Start(),


### PR DESCRIPTION
The peer list can temporarily become empty when using Redis discovery
and the Redis state is lost (e.g. restarting an in-memory instance).
This causes a divide by zero panic when attempting to chose a shard and
results in dropping spans that may have already been correctly routed by
another peer.

I experienced this while running a load test to confirm the behaviour
when Redis becomes unavailable. It continues working fine while Redis is
unavailable, but it resulted in these panics when Redis came back:

    $ kc logs samproxy-96765ff85-44qg5
    time="2020-06-10T14:13:34Z" level=info msg="using identifier from interface" identifier=172.17.0.7 interface=eth0
    time="2020-06-10T14:15:52Z" level=error msg="redis scan encountered an error" err=EOF keys_returned=0 timeoutSec=5s
    time="2020-06-10T14:15:52Z" level=error msg="redis scan encountered an error" err=EOF keys_returned=0 timeoutSec=5s
    time="2020-06-10T14:15:52Z" level=error msg="handler returning error" error.err="caught panic: runtime error: integer divide by zero" error.msg="caught panic" error.status_code=500
    time="2020-06-10T14:15:53Z" level=error msg="handler returning error" error.err="caught panic: runtime error: integer divide by zero" error.msg="caught panic" error.status_code=500
    time="2020-06-10T14:15:53Z" level=error msg="handler returning error" error.err="caught panic: runtime error: integer divide by zero" error.msg="caught panic" error.status_code=500
    $ kc logs samproxy-96765ff85-2zkzw
    time="2020-06-10T14:13:32Z" level=info msg="using identifier from interface" identifier=172.17.0.10 interface=eth0
    time="2020-06-10T14:15:52Z" level=error msg="non-20x response when sending event" api_host="http://172.17.0.7:8081" dataset=beeline-go event_type=unknown status_code=500 target=unknown
    time="2020-06-10T14:15:52Z" level=error msg="non-20x response when sending event" api_host="http://172.17.0.7:8081" dataset=beeline-go event_type=unknown status_code=500 target=unknown
    time="2020-06-10T14:15:52Z" level=error msg="non-20x response when sending event" api_host="http://172.17.0.7:8081" dataset=beeline-go event_type=unknown status_code=500 target=unknown

No spans were dropped after repeating the test with this change. There's
always going to be a possible race condition with some inconsistent
sharding/sampling as the peers re-register and refresh the lists at
different intervals, but this will deal with the worst case.

Returning an error when there are no peers means that it will surface
the error to the logs and re-attempt later. I considered putting the
check beneath the URL parsing but there's no benefit since that will
return an error rather than continuing without a peer.

We originally discussed only keeping the peer list if there was
previously a non-zero peer list but that seems unnecessary to check
since it can't start with a non-zero peer list (`Start` will return an
error if it can't find itself).