### PR TITLE
ticker-based sends

### DIFF
--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -124,7 +124,8 @@ func (d *DefaultInMemCache) GetTracesToSend() []*types.Trace {
 	var traces []*types.Trace
 	for _, tr := range d.insertionOrder {
 		if tr != nil && !tr.SendBy.IsZero() && tr.SendBy.Before(now) {
-			tr.SendBy = time.Time{}
+			// set SendBy to the zero time to skip it next time.
+			tr.SendBy = time.Time{}			
 			traces = append(traces, tr)
 		}
 	}

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -233,7 +233,10 @@ func (i *InMemCollector) collect() {
 		// ok, the peer queue is low enough, let's wait for new events from anywhere
 		select {
 		case <-i.sendTicker.C:
+			now := time.Now()
 			for _, trace := range i.Cache.GetTracesToSend() {
+				// TODO fix FinishTime to be the time of the last span + its duration
+				trace.FinishTime = now
 				i.send(trace)
 			}
 		case sp, ok := <-i.incoming:

--- a/types/event.go
+++ b/types/event.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"context"
-	"sync"
 	"time"
 )
 
@@ -95,8 +94,6 @@ type Trace struct {
 	// FinishTime is when a trace is prepared for sending; it does not include
 	// any additional delay imposed by the DelaySend config option.
 	FinishTime time.Time
-
-	SendOnce sync.Once
 
 	// spans is the list of spans in this trace
 	spans []*Span

--- a/types/event.go
+++ b/types/event.go
@@ -115,6 +115,9 @@ func (t *Trace) GetSpans() []*Span {
 	return t.spans
 }
 
+// SetDeadline sets the deadline that this trace should be sent by
+// When we check for traces to send any trace that has exceeded the
+// deadline will be sent
 func (t *Trace) SetDeadline(d time.Duration) {
 	deadline := time.Now().Add(d)
 	if t.SendBy.IsZero() || t.SendBy.After(deadline) {

--- a/types/event.go
+++ b/types/event.go
@@ -115,9 +115,10 @@ func (t *Trace) GetSpans() []*Span {
 	return t.spans
 }
 
-// SetDeadline sets the deadline that this trace should be sent by
-// When we check for traces to send any trace that has exceeded the
-// deadline will be sent
+// SetDeadline sets the deadline after which this trace should be sent. It
+// will get sent sometime after the deadline expires (by a ticker check) but
+// not before. If a deadline has already been set, this call will only shrink
+// the deadline, not expand it. 
 func (t *Trace) SetDeadline(d time.Duration) {
 	deadline := time.Now().Add(d)
 	if t.SendBy.IsZero() || t.SendBy.After(deadline) {


### PR DESCRIPTION
Moves samproxy to process accumulated traces on a single time interval instead of per trace. As per refinery:

> Note this doesn't move the benchmark needle because it's stuck waiting for the ticker, but it uses a whole lot less CPU to do the same job in the same time.

https://github.com/honeycombio/hound/pull/3042