### PR TITLE
collect: Fix some missing metrics

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -105,8 +105,9 @@ func (i *InMemCollector) Start() error {
 	// listen for config reloads
 	i.Config.RegisterReloadCallback(i.sendReloadSignal)
 
-	i.Metrics.Register("trace_duration", "histogram")
-	i.Metrics.Register("trace_num_spans", "histogram")
+	i.Metrics.Register("trace_duration_ms", "histogram")
+	i.Metrics.Register("trace_span_count", "histogram")
+	i.Metrics.Register("collector_tosend_queue", "histogram")
 	i.Metrics.Register("collector_incoming_queue", "histogram")
 	i.Metrics.Register("collector_peer_queue", "histogram")
 	i.Metrics.Register("trace_sent_cache_hit", "counter")


### PR DESCRIPTION
These metrics weren't being reported because they were registered with
the wrong name or not registered at all. I originally noticed that
duration and span count were always zero in our installation and then
found the others with:

    $ for metric in $(rg '.*(IncrementCounter|Histogram)\("(.*)".*' -Ir '$2'); do rg -q "Register\(\"$metric\"" || echo $metric; done
    collector_tosend_queue
    trace_span_count
    trace_duration_ms

The `metrics` package could be made more resilient or more obvious to
this happening in the future.

---

The `honeycomb` metrics implementation registers metrics if they aren't already registered. What do you think about the `prometheus` implementation doing the same and removing the explicit `Register` calls altogether?