### PR TITLE
collect: Remove unregistered trace_sent metric

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -410,12 +410,9 @@ func (i *InMemCollector) send(trace *types.Trace) {
 	}
 	trace.Sent = true
 
-	// we're sending this trace, bump the counter
-	i.Metrics.IncrementCounter("trace_sent")
-	i.Metrics.Histogram("trace_span_count", float64(len(trace.GetSpans())))
-
 	traceDur := float64(trace.FinishTime.Sub(trace.StartTime) / time.Millisecond)
 	i.Metrics.Histogram("trace_duration_ms", traceDur)
+	i.Metrics.Histogram("trace_span_count", float64(len(trace.GetSpans())))
 
 	var sampler sample.Sampler
 	var found bool


### PR DESCRIPTION
This metric wasn't being reported because it wasn't registered. On
closer inspection, it seems unnecessary because the "sent" is misleading
when the trace could have been dropped by sampling and there are more
specific metrics recorded for `trace_send_kept` and `trace_send_dropped`