### PR TITLE
ticker-based sends v2

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -203,7 +203,15 @@ func (i *InMemCollector) collect() {
 		}
 	}()
 
-	incoming := mergeIncomingSpans(i.incoming, i.fromPeer)
+	incoming := mergeIncomingSpans(spanInput{
+		ch:          i.incoming,
+		name:        "from_incoming",
+		concurrency: 1,
+	}, spanInput{
+		ch:          i.fromPeer,
+		name:        "from_peer",
+		concurrency: 2,
+	})
 
 	for {
 		// record channel lengths

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -25,6 +25,7 @@ func TestAddRootSpan(t *testing.T) {
 		GetSendDelayVal:          0,
 		GetTraceTimeoutVal:       60,
 		GetDefaultSamplerTypeVal: "DeterministicSampler",
+		SendTickerVal:            2 * time.Millisecond,
 	}
 	coll := &InMemCollector{
 		Config:         conf,
@@ -66,7 +67,7 @@ func TestAddRootSpan(t *testing.T) {
 		},
 	}
 	coll.AddSpan(span)
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(conf.SendTickerVal * 2)
 	// adding one span with no parent ID should:
 	// * create the trace in the cache
 	// * send the trace
@@ -81,7 +82,7 @@ func TestAddRootSpan(t *testing.T) {
 		},
 	}
 	coll.AddSpanFromPeer(span)
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(conf.SendTickerVal * 2)
 	// adding one span with no parent ID should:
 	// * create the trace in the cache
 	// * send the trace

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -101,6 +101,7 @@ func TestAddSpan(t *testing.T) {
 		GetSendDelayVal:          0,
 		GetTraceTimeoutVal:       60,
 		GetDefaultSamplerTypeVal: "DeterministicSampler",
+		SendTickerVal:            2 * time.Millisecond,
 	}
 	coll := &InMemCollector{
 		Config:         conf,
@@ -143,7 +144,7 @@ func TestAddSpan(t *testing.T) {
 		},
 	}
 	coll.AddSpanFromPeer(span)
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(conf.SendTickerVal * 2)
 	assert.Equal(t, traceID, coll.Cache.Get(traceID).TraceID, "after adding the span, we should have a trace in the cache with the right trace ID")
 	assert.Equal(t, 0, len(transmission.Events), "adding a non-root span should not yet send the span")
 	// ok now let's add the root span and verify that both got sent
@@ -155,7 +156,7 @@ func TestAddSpan(t *testing.T) {
 		},
 	}
 	coll.AddSpan(rootSpan)
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(conf.SendTickerVal * 2)
 	assert.Equal(t, 2, len(coll.Cache.Get(traceID).GetSpans()), "after adding a leaf and root span, we should have a two spans in the cache")
 	assert.Equal(t, 2, len(transmission.Events), "adding a root span should send all spans in the trace")
 }

--- a/collect/pipeline.go
+++ b/collect/pipeline.go
@@ -12,6 +12,11 @@ type spanInput struct {
 	name        string
 }
 
+// mergeIncomingSpans accepts a variable number of spanInputs. Each spanInput says 
+// which span channel to pull from and how many goroutines should be doing the pulling.
+// By adjusting the concurrency field in the spanInput, you can give some channels a 
+// higher throughput than others. The resulting channel merges inputs from all listed 
+// incoming channels.
 func mergeIncomingSpans(in ...spanInput) <-chan *types.Span {
 	var wg sync.WaitGroup
 	out := make(chan *types.Span)

--- a/collect/pipeline.go
+++ b/collect/pipeline.go
@@ -1,0 +1,32 @@
+package collect
+
+import (
+	"sync"
+
+	"github.com/honeycombio/samproxy/types"
+)
+
+func mergeIncomingSpans(in ...<-chan *types.Span) <-chan *types.Span {
+	var wg sync.WaitGroup
+	out := make(chan *types.Span)
+
+	output := func(c <-chan *types.Span) {
+		for n := range c {
+			out <- n
+		}
+		wg.Done()
+	}
+
+	wg.Add(len(in))
+
+	for _, c := range in {
+		go output(c)
+	}
+
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+
+	return out
+}

--- a/collect/pipeline_test.go
+++ b/collect/pipeline_test.go
@@ -1,0 +1,36 @@
+package collect
+
+import (
+	"testing"
+
+	"github.com/honeycombio/samproxy/types"
+)
+
+func TestMergeIncomingSpans(t *testing.T) {
+	n := 20
+
+	ch1 := make(chan *types.Span)
+	ch2 := make(chan *types.Span)
+
+	out := mergeIncomingSpans(ch1, ch2)
+
+	var count int
+
+	go func() {
+		defer close(ch1)
+		defer close(ch2)
+
+		for i := 0; i < n/2; i++ {
+			ch1 <- &types.Span{}
+			ch2 <- &types.Span{}
+		}
+	}()
+
+	for range out {
+		count++
+	}
+
+	if count != n {
+		t.Fail()
+	}
+}

--- a/collect/pipeline_test.go
+++ b/collect/pipeline_test.go
@@ -12,7 +12,15 @@ func TestMergeIncomingSpans(t *testing.T) {
 	ch1 := make(chan *types.Span)
 	ch2 := make(chan *types.Span)
 
-	out := mergeIncomingSpans(ch1, ch2)
+	out := mergeIncomingSpans(spanInput{
+		ch:          ch1,
+		concurrency: 1,
+		name:        "1",
+	}, spanInput{
+		ch:          ch2,
+		concurrency: 2,
+		name:        "2",
+	})
 
 	var count int
 

--- a/config/config.go
+++ b/config/config.go
@@ -89,4 +89,7 @@ type Config interface {
 	// GetPeerBufferSize returns the size of the libhoney buffer to use for the peer forwarding
 	// libhoney client
 	GetPeerBufferSize() int
+
+	// GetSendTickerValue returns the duration to use to check for traces to send
+	GetSendTickerValue() time.Duration
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,6 +24,10 @@ func TestReadDefaultFile(t *testing.T) {
 	if d, _ := c.GetTraceTimeout(); d != 60*time.Second {
 		t.Error("received", d, "expected", 60*time.Second)
 	}
+
+	if d := c.GetSendTickerValue(); d != 100*time.Millisecond {
+		t.Error("received", d, "expected", 100*time.Millisecond)
+	}
 }
 
 func TestGetSamplerTypes(t *testing.T) {

--- a/config/fileconfig.go
+++ b/config/fileconfig.go
@@ -33,6 +33,7 @@ type confContents struct {
 	Metrics                 string
 	SendDelay               time.Duration
 	TraceTimeout            time.Duration
+	SendTicker              time.Duration
 	UpstreamBufferSize      int
 	PeerBufferSize          int
 }
@@ -56,7 +57,11 @@ func (f *FileConfig) reloadConfig() error {
 		return err
 	}
 	f.rawConf = config
-	f.conf = confContents{}
+
+	// set the defaults here which are used when the key is not present in the file
+	f.conf = confContents{
+		SendTicker: 100 * time.Millisecond,
+	}
 	err = config.Unmarshal(&f.conf)
 	if err != nil {
 		return err
@@ -180,4 +185,8 @@ func (f *FileConfig) GetPeerBufferSize() int {
 		return libhoney.DefaultPendingWorkCapacity
 	}
 	return f.conf.PeerBufferSize
+}
+
+func (f *FileConfig) GetSendTickerValue() time.Duration {
+	return f.conf.SendTicker
 }

--- a/config/mock.go
+++ b/config/mock.go
@@ -39,6 +39,7 @@ type MockConfig struct {
 	GetTraceTimeoutVal       time.Duration
 	GetUpstreamBufferSizeVal int
 	GetPeerBufferSizeVal     int
+	SendTickerVal            time.Duration
 }
 
 func (m *MockConfig) ReloadConfig()                 {}
@@ -90,4 +91,8 @@ func (m *MockConfig) GetUpstreamBufferSize() int {
 }
 func (m *MockConfig) GetPeerBufferSize() int {
 	return m.GetPeerBufferSizeVal
+}
+
+func (m *MockConfig) GetSendTickerValue() time.Duration {
+	return m.SendTickerVal
 }

--- a/types/event.go
+++ b/types/event.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"context"
-	"sync"
 	"time"
 )
 
@@ -86,6 +85,8 @@ type Trace struct {
 	// Sent should only be changed if the changer holds the SendSampleLock
 	Sent bool
 
+	SendBy time.Time
+
 	// StartTime is the server time when the first span arrived for this trace.
 	// Used to calculate how long traces spend sitting in Samproxy
 	StartTime time.Time
@@ -93,15 +94,7 @@ type Trace struct {
 	// any additional delay imposed by the DelaySend config option.
 	FinishTime time.Time
 
-	// CanceSending is a channel used to abort the trace timeout if we send or
-	// sample this trace so that we're not sitting around with tons of goroutines
-	// waiting a full minute (or whatever the trace timeout is) then doing nothing.
-	// Closing this channel will cause any still-waiting send timers to exit.
-	CancelSending chan struct{}
-
-	SendOnce sync.Once
-
-	// spans is the list of spans in this trace, protected by the list lock
+	// spans is the list of spans in this trace
 	spans []*Span
 }
 


### PR DESCRIPTION
A change from #65. This merges the incoming and peer span channels into a single channel fed by multiple go routines to prioritize the peer events. This simplifies the select in the `collect` function.