### PR TITLE
add samproxy version via user agent addition

### DIFF
--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -30,6 +30,7 @@ type DefaultTransmission struct {
 	Config     config.Config   `inject:""`
 	Logger     logger.Logger   `inject:""`
 	Metrics    metrics.Metrics `inject:""`
+	Version    string          `inject:"version"`
 	LibhClient *libhoney.Client
 
 	// Type is peer or upstream, and used only for naming metrics
@@ -49,6 +50,7 @@ func (d *DefaultTransmission) Start() error {
 	if err != nil {
 		return err
 	}
+	libhoney.UserAgentAddition = "samproxy/" + d.Version
 	d.builder = d.LibhClient.NewBuilder()
 	d.builder.APIHost = upstreamAPI
 

--- a/transmit/transmit_test.go
+++ b/transmit/transmit_test.go
@@ -1,1 +1,27 @@
 package transmit
+
+import (
+	"testing"
+
+	"github.com/honeycombio/samproxy/config"
+	"github.com/honeycombio/samproxy/logger"
+	"github.com/honeycombio/samproxy/metrics"
+
+	libhoney "github.com/honeycombio/libhoney-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultTransmissionUpdatesUserAgentAdditionAfterStart(t *testing.T) {
+	transmission := &DefaultTransmission{
+		Config:     &config.MockConfig{},
+		Logger:     &logger.NullLogger{},
+		Metrics:    &metrics.NullMetrics{},
+		LibhClient: &libhoney.Client{},
+		Version:    "test",
+	}
+
+	assert.Equal(t, libhoney.UserAgentAddition, "")
+	err := transmission.Start()
+	assert.Nil(t, err)
+	assert.Equal(t, libhoney.UserAgentAddition, "samproxy/test")
+}


### PR DESCRIPTION
Add `samproxy/version` to user agent addition to show that events are being sent via samproxy.