### PR TITLE
Use time.duration for config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -82,8 +82,8 @@ HoneycombAPI = "https://api.honeycomb.io"
 # Samproxy will wait this duration before actually sending the trace.  The
 # reason for this short delay is to allow for small network delays or clock
 # jitters to elapse and any final spans to arrive before actually sending the
-# trace. This timer is in seconds. Set to 0 for immediate
-# sends.
+# trace.  This supports duration strings with supplied units. Set to 0 for
+# immediate sends.
 # Eligible for live reload.
 SendDelay = "2s"
 
@@ -92,7 +92,7 @@ SendDelay = "2s"
 # root span arrives. Sometimes the root span never arrives (due to crashes or
 # whatever), and this timer will send a trace even without having received the
 # root span. If you have particularly long-lived traces you should increase this
-# timer. This timer is in seconds.
+# timer. This supports duration strings with supplied units.
 # Eligible for live reload.
 TraceTimeout = "60s"
 

--- a/config.toml
+++ b/config.toml
@@ -85,7 +85,7 @@ HoneycombAPI = "https://api.honeycomb.io"
 # trace. This timer is in seconds. Set to 0 for immediate
 # sends.
 # Eligible for live reload.
-SendDelay = 2
+SendDelay = "2s"
 
 # TraceTimeout is a long timer; it represents the outside boundary of how long
 # to wait before sending an incomplete trace. Normally traces are sent when the
@@ -94,7 +94,7 @@ SendDelay = 2
 # root span. If you have particularly long-lived traces you should increase this
 # timer. This timer is in seconds.
 # Eligible for live reload.
-TraceTimeout = 60
+TraceTimeout = "60s"
 
 # LoggingLevel is the level above which we should log. Debug is very verbose,
 # and should only be used in pre-production environments. Info is the
@@ -248,8 +248,8 @@ CacheCapacity = 1000
 
 		# EMADynamicSampler is a section of the config for manipulating the Exponential
 		# Moving Average (EMA) Dynamic Sampler implementation. Like the simple DynamicSampler,
-		# it attempts to average a given sample rate, weighting rare traffic and frequent 
-		# traffic differently so as to end up with the correct average. 
+		# it attempts to average a given sample rate, weighting rare traffic and frequent
+		# traffic differently so as to end up with the correct average.
 		#
 		# EMADynamicSampler is an improvement upon the simple DynamicSampler and is recommended
 		# for most use cases. Based on the DynamicSampler implementation, EMADynamicSampler differs

--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,7 @@
 package config
 
+import "time"
+
 // Config defines the interface the rest of the code uses to get items from the
 // config. There are different implementations of the config using different
 // backends to store the config. FileConfig is the default and uses a
@@ -49,18 +51,12 @@ type Config interface {
 
 	// GetSendDelay returns the number of seconds to pause after a trace is
 	// complete before sending it, to allow stragglers to arrive
-	GetSendDelay() (int, error)
+	GetSendDelay() (time.Duration, error)
 
 	// GetTraceTimeout is how long to wait before sending a trace even if it's
 	// not complete. This should be longer than the longest expected trace
 	// duration.
-	GetTraceTimeout() (int, error)
-
-	// GetSpanSeenDelay is a timer that bumps out sending the trace every time a
-	// span is received. This one is used if you have traces of widely variable
-	// duration, but don't want them to get sent until all spans arrive. Use with
-	// care - if a trace continues to accumulate spans it may never get sent.
-	GetSpanSeenDelay() (int, error)
+	GetTraceTimeout() (time.Duration, error)
 
 	// GetOtherConfig attempts to fill the passed in struct with the contents of
 	// a subsection of the config.   This is used by optional configurations to

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,9 +4,27 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestReadDefaultFile(t *testing.T) {
+	c := FileConfig{Path: "../config.toml"}
+	err := c.Start()
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if d, _ := c.GetSendDelay(); d != 2*time.Second {
+		t.Error("received", d, "expected", 2*time.Second)
+	}
+
+	if d, _ := c.GetTraceTimeout(); d != 60*time.Second {
+		t.Error("received", d, "expected", 60*time.Second)
+	}
+}
 
 func TestGetSamplerTypes(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "")

--- a/config/fileconfig.go
+++ b/config/fileconfig.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"time"
 
 	libhoney "github.com/honeycombio/libhoney-go"
 	toml "github.com/pelletier/go-toml"
@@ -30,9 +31,8 @@ type confContents struct {
 	Collector               string
 	Sampler                 string
 	Metrics                 string
-	SendDelay               int
-	SpanSeenDelay           int
-	TraceTimeout            int
+	SendDelay               time.Duration
+	TraceTimeout            time.Duration
 	UpstreamBufferSize      int
 	PeerBufferSize          int
 }
@@ -152,15 +152,11 @@ func (f *FileConfig) GetMetricsType() (string, error) {
 	return f.conf.Metrics, nil
 }
 
-func (f *FileConfig) GetSendDelay() (int, error) {
+func (f *FileConfig) GetSendDelay() (time.Duration, error) {
 	return f.conf.SendDelay, nil
 }
 
-func (f *FileConfig) GetSpanSeenDelay() (int, error) {
-	return f.conf.SpanSeenDelay, nil
-}
-
-func (f *FileConfig) GetTraceTimeout() (int, error) {
+func (f *FileConfig) GetTraceTimeout() (time.Duration, error) {
 	return f.conf.TraceTimeout, nil
 }
 

--- a/config/mock.go
+++ b/config/mock.go
@@ -1,6 +1,9 @@
 package config
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"time"
+)
 
 // MockConfig will respond with whatever config it's set to do during
 // initialization
@@ -31,11 +34,9 @@ type MockConfig struct {
 	GetMetricsTypeErr        error
 	GetMetricsTypeVal        string
 	GetSendDelayErr          error
-	GetSendDelayVal          int
-	GetSpanSeenDelayErr      error
-	GetSpanSeenDelayVal      int
+	GetSendDelayVal          time.Duration
 	GetTraceTimeoutErr       error
-	GetTraceTimeoutVal       int
+	GetTraceTimeoutVal       time.Duration
 	GetUpstreamBufferSizeVal int
 	GetPeerBufferSizeVal     int
 }
@@ -69,12 +70,15 @@ func (m *MockConfig) GetRedisHost() (string, error) { return m.GetRedisHostVal, 
 func (m *MockConfig) GetDefaultSamplerType() (string, error) {
 	return m.GetDefaultSamplerTypeVal, m.GetDefaultSamplerTypeErr
 }
-func (m *MockConfig) GetMetricsType() (string, error) { return m.GetMetricsTypeVal, m.GetMetricsTypeErr }
-func (m *MockConfig) GetSendDelay() (int, error)      { return m.GetSendDelayVal, m.GetSendDelayErr }
-func (m *MockConfig) GetSpanSeenDelay() (int, error) {
-	return m.GetSpanSeenDelayVal, m.GetSpanSeenDelayErr
+func (m *MockConfig) GetMetricsType() (string, error) {
+	return m.GetMetricsTypeVal, m.GetMetricsTypeErr
 }
-func (m *MockConfig) GetTraceTimeout() (int, error) { return m.GetTraceTimeoutVal, m.GetTraceTimeoutErr }
+func (m *MockConfig) GetSendDelay() (time.Duration, error) {
+	return m.GetSendDelayVal, m.GetSendDelayErr
+}
+func (m *MockConfig) GetTraceTimeout() (time.Duration, error) {
+	return m.GetTraceTimeoutVal, m.GetTraceTimeoutErr
+}
 
 // TODO: allow per-dataset mock values
 func (m *MockConfig) GetSamplerTypeForDataset(dataset string) (string, error) {


### PR DESCRIPTION
Read `time.Duration` direct from the TOML file. 

🚨 This is a breaking config change 🚨

Also removes unused config value GetSpanSeenDelay