### PR TITLE
sample: Add key to all spans

### DIFF
--- a/sample/dynamic.go
+++ b/sample/dynamic.go
@@ -227,39 +227,11 @@ func (d *DynamicSampler) buildKey(trace *types.Trace) string {
 		key += strconv.FormatInt(int64(len(spans)), 10)
 	}
 
-	// if we should add the key used by the dynsampler to the root span, let's
-	// do so now.
 	if d.addDynsampleKey {
-		span := findRootSpan(trace)
-		if span != nil {
+		for _, span := range trace.GetSpans() {
 			span.Data[d.addDynsampleField] = key
-		} else {
-			d.Logger.WithField("trace_id", trace.TraceID).Debugf("no root span found; not adding dynsampler key to the trace")
 		}
 	}
 
 	return key
-}
-
-// findRootSpan selects the root span from the list of spans in a trace. If it
-// can't find a root span it returns nil.
-func findRootSpan(trace *types.Trace) *types.Span {
-	for _, span := range trace.GetSpans() {
-		if isRootSpan(span) {
-			return span
-		}
-	}
-	return nil
-}
-
-func isRootSpan(sp *types.Span) bool {
-	parentID := sp.Data["trace.parent_id"]
-	if parentID == nil {
-		parentID = sp.Data["parentId"]
-		if parentID == nil {
-			// no parent ID present; it's a root span
-			return true
-		}
-	}
-	return false
 }

--- a/sample/dynamic_ema.go
+++ b/sample/dynamic_ema.go
@@ -267,14 +267,9 @@ func (d *EMADynamicSampler) buildKey(trace *types.Trace) string {
 		key += strconv.FormatInt(int64(len(spans)), 10)
 	}
 
-	// if we should add the key used by the dynsampler to the root span, let's
-	// do so now.
 	if d.addDynsampleKey {
-		span := findRootSpan(trace)
-		if span != nil {
+		for _, span := range trace.GetSpans() {
 			span.Data[d.addDynsampleField] = key
-		} else {
-			d.Logger.WithField("trace_id", trace.TraceID).Debugf("no root span found; not adding dynsampler key to the trace")
 		}
 	}
 

--- a/sample/dynamic_ema_test.go
+++ b/sample/dynamic_ema_test.go
@@ -1,0 +1,54 @@
+package sample
+
+import (
+	"testing"
+
+	"github.com/honeycombio/samproxy/config"
+	"github.com/honeycombio/samproxy/logger"
+	"github.com/honeycombio/samproxy/metrics"
+	"github.com/honeycombio/samproxy/types"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDynamicEMAAddSampleRateKeyToTrace(t *testing.T) {
+	const spanCount = 5
+
+	metrics := metrics.MockMetrics{}
+	metrics.Start()
+
+	config := &config.MockConfig{
+		GetOtherConfigVal: `{
+  "FieldList":["http.status_code"],
+  "AddSampleRateKeyToTrace":true,
+  "AddSampleRateKeyToTraceField":"meta.key"
+}`,
+	}
+	sampler := &EMADynamicSampler{
+		Config:  config,
+		Logger:  &logger.NullLogger{},
+		Metrics: &metrics,
+	}
+
+	trace := &types.Trace{}
+	for i := 0; i < spanCount; i++ {
+		trace.AddSpan(&types.Span{
+			Event: types.Event{
+				Data: map[string]interface{}{
+					"http.status_code": "200",
+				},
+			},
+		})
+	}
+	sampler.Start()
+	sampler.GetSampleRate(trace)
+
+	spans := trace.GetSpans()
+	assert.Len(t, spans, spanCount, "should have the same number of spans as input")
+	for _, span := range spans {
+		assert.Equal(t, span.Event.Data, map[string]interface{}{
+			"http.status_code": "200",
+			"meta.key":         "200•,",
+		}, "should add the sampling key to all spans in the trace")
+	}
+}

--- a/sample/dynamic_test.go
+++ b/sample/dynamic_test.go
@@ -1,0 +1,54 @@
+package sample
+
+import (
+	"testing"
+
+	"github.com/honeycombio/samproxy/config"
+	"github.com/honeycombio/samproxy/logger"
+	"github.com/honeycombio/samproxy/metrics"
+	"github.com/honeycombio/samproxy/types"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDynamicAddSampleRateKeyToTrace(t *testing.T) {
+	const spanCount = 5
+
+	metrics := metrics.MockMetrics{}
+	metrics.Start()
+
+	config := &config.MockConfig{
+		GetOtherConfigVal: `{
+  "FieldList":["http.status_code"],
+  "AddSampleRateKeyToTrace":true,
+  "AddSampleRateKeyToTraceField":"meta.key"
+}`,
+	}
+	sampler := &DynamicSampler{
+		Config:  config,
+		Logger:  &logger.NullLogger{},
+		Metrics: &metrics,
+	}
+
+	trace := &types.Trace{}
+	for i := 0; i < spanCount; i++ {
+		trace.AddSpan(&types.Span{
+			Event: types.Event{
+				Data: map[string]interface{}{
+					"http.status_code": "200",
+				},
+			},
+		})
+	}
+	sampler.Start()
+	sampler.GetSampleRate(trace)
+
+	spans := trace.GetSpans()
+	assert.Len(t, spans, spanCount, "should have the same number of spans as input")
+	for _, span := range spans {
+		assert.Equal(t, span.Event.Data, map[string]interface{}{
+			"http.status_code": "200",
+			"meta.key":         "200•,",
+		}, "should add the sampling key to all spans in the trace")
+	}
+}


### PR DESCRIPTION
Add the key to all spans within the trace rather than just the root.
There is no additional cost to users storing these in Honeycomb and they
will make it easier to see which keys are contributing to the total rate
by number of spans.

We need this to verify what keys are being used for a large number of
events that we suspect belong to a small number of deep traces. We can't
currently figure out how to query that from Honeycomb because only the
root spans appear when grouped by sampler key. It also can't be combined
with the server-side method for counting the number of spans within a
trace:

- https://docs.honeycomb.io/working-with-your-data/tracing/#span-count-per-trace

We've added simple tests that verify the trace/span pointers are updated
correctly. These tests could be extended to verify other dynamic sampler
functionality in the future, but we don't intend to do that ourselves.
The functions for finding a root span are removed because they are no
longer used.

Paired with Claire Alvis.