### PR TITLE
add debug service and enable with debug flag

### DIFF
--- a/cmd/samproxy/main.go
+++ b/cmd/samproxy/main.go
@@ -36,7 +36,7 @@ type Options struct {
 	RulesFile  string `short:"r" long:"rules_config" description:"Path to rules config file" default:"/etc/samproxy/rules.toml"`
 	PeerType   string `short:"p" long:"peer_type" description:"Peer type - should be redis or file" default:"file"`
 	Version    bool   `short:"v" long:"version" description:"Print version number and exit"`
-	Debug      bool   `short:"d" long:"debug" description:"If enabled, runs debug service on port 6060"`
+	Debug      bool   `short:"d" long:"debug" description:"If enabled, runs debug service (default port 6060)"`
 }
 
 func main() {
@@ -177,9 +177,11 @@ func main() {
 	}
 
 	if opts.Debug {
-		g.Provide(
-			&inject.Object{Value: &debug.DebugService{}},
-		)
+		err = g.Provide(&inject.Object{Value: &debug.DebugService{}})
+		if err != nil {
+			fmt.Printf("failed to provide injection graph. error: %+v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	if err := g.Populate(); err != nil {

--- a/cmd/samproxy/main.go
+++ b/cmd/samproxy/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/honeycombio/samproxy/logger"
 	"github.com/honeycombio/samproxy/metrics"
 	"github.com/honeycombio/samproxy/sample"
+	"github.com/honeycombio/samproxy/service/debug"
 	"github.com/honeycombio/samproxy/sharder"
 	"github.com/honeycombio/samproxy/transmit"
 )
@@ -35,6 +36,7 @@ type Options struct {
 	RulesFile  string `short:"r" long:"rules_config" description:"Path to rules config file" default:"/etc/samproxy/rules.toml"`
 	PeerType   string `short:"p" long:"peer_type" description:"Peer type - should be redis or file" default:"file"`
 	Version    bool   `short:"v" long:"version" description:"Print version number and exit"`
+	Debug      bool   `short:"d" long:"debug" description:"If enabled, runs debug service on port 6060"`
 }
 
 func main() {
@@ -173,6 +175,13 @@ func main() {
 		fmt.Printf("failed to provide injection graph. error: %+v\n", err)
 		os.Exit(1)
 	}
+
+	if opts.Debug {
+		g.Provide(
+			&inject.Object{Value: &debug.DebugService{}},
+		)
+	}
+
 	if err := g.Populate(); err != nil {
 		fmt.Printf("failed to populate injection graph. error: %+v\n", err)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -24,9 +24,10 @@ require (
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/klauspost/compress v1.9.1
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
-	github.com/pelletier/go-toml v1.8.0
+	github.com/pelletier/go-toml v1.8.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3
+	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0
 	github.com/sirupsen/logrus v1.2.0
 	github.com/spf13/afero v1.3.2 // indirect
 	github.com/spf13/cast v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084 h1:sofwID9zm4tzrgykg80hfFph1mryUeLRsUfoocVVmRY=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 h1:MkV+77GLUNo5oJ0jf870itWm3D0Sjh7+Za9gazKc5LQ=
+github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=

--- a/service/debug/debug_service.go
+++ b/service/debug/debug_service.go
@@ -1,0 +1,156 @@
+package debug
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"log"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"runtime"
+	"strconv"
+	"sync"
+	"syscall"
+
+	metrics "github.com/rcrowley/go-metrics"
+	"github.com/rcrowley/go-metrics/exp"
+	"github.com/sirupsen/logrus"
+)
+
+const addr = "localhost:6060"
+
+// injectable debug service
+type DebugService struct {
+	mux     *http.ServeMux
+	urls    []string
+	expVars map[string]interface{}
+	mutex   sync.RWMutex
+}
+
+func (s *DebugService) Start() error {
+	s.expVars = make(map[string]interface{})
+
+	s.mux = http.NewServeMux()
+
+	// Add to the mux but don't add an index entry.
+	s.mux.HandleFunc("/", s.indexHandler)
+
+	s.HandleFunc("/debug/pprof/", pprof.Index)
+	s.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	s.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	s.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	s.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	s.HandleFunc("/debug/vars", s.expvarHandler)
+	s.Handle("/debug/metrics", exp.ExpHandler(metrics.DefaultRegistry))
+	s.Publish("cmdline", os.Args)
+	s.Publish("memstats", Func(memstats))
+
+	go func() {
+		// Prefer to listen on addr, but will try to bind to the next 9 ports
+		// in case you have multiple services running on the same host.
+		for i := 0; i < 10; i++ {
+			host, portStr, _ := net.SplitHostPort(addr)
+			port, _ := strconv.Atoi(portStr)
+			port += i
+			addr := net.JoinHostPort(host, fmt.Sprint(port))
+
+			logrus.Infof("Debug service listening on %s", addr)
+
+			err := http.ListenAndServe(addr, s.mux)
+			logrus.WithError(err).Warn("debug http server error")
+
+			if err, ok := err.(*net.OpError); ok {
+				if err, ok := err.Err.(*os.SyscallError); ok {
+					if err.Err == syscall.EADDRINUSE {
+						// address already in use, try another
+						continue
+					}
+				}
+			}
+			break
+		}
+	}()
+
+	return nil
+}
+
+// Use Handle and HandleFunc to add new services on the internal debugging port.
+func (s *DebugService) Handle(pattern string, handler http.Handler) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.urls = append(s.urls, pattern)
+	s.mux.Handle(pattern, handler)
+}
+
+func (s *DebugService) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.urls = append(s.urls, pattern)
+	s.mux.HandleFunc(pattern, handler)
+}
+
+// Publish an expvar at /debug/vars, possibly using Func
+func (s *DebugService) Publish(name string, v interface{}) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if _, existing := s.expVars[name]; existing {
+		log.Panicln("Reuse of exported var name:", name)
+	}
+	s.expVars[name] = v
+}
+
+func (s *DebugService) indexHandler(w http.ResponseWriter, req *http.Request) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	if err := indexTmpl.Execute(w, s.urls); err != nil {
+		logrus.WithError(err).Warn("error rendering debug index")
+	}
+}
+
+var indexTmpl = template.Must(template.New("index").Parse(`
+<html>
+<head>
+<title>Debug Index</title>
+</head>
+<body>
+<h2>Index</h2>
+<table>
+{{range .}}
+<tr><td><a href="{{.}}?debug=1">{{.}}</a>
+{{end}}
+</table>
+</body>
+</html>
+`))
+
+func (s *DebugService) expvarHandler(w http.ResponseWriter, r *http.Request) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	values := make(map[string]interface{}, len(s.expVars))
+	for k, v := range s.expVars {
+		if f, ok := v.(Func); ok {
+			v = f()
+		}
+		values[k] = v
+	}
+	b, err := json.MarshalIndent(values, "", "  ")
+	if err != nil {
+		logrus.WithError(err).Warn("error encoding expvars")
+	}
+	w.Write(b)
+}
+
+func memstats() interface{} {
+	stats := new(runtime.MemStats)
+	runtime.ReadMemStats(stats)
+	return *stats
+}
+
+type Func func() interface{}


### PR DESCRIPTION
Add `-debug` flag which when used, will run a debug service on port 6060.  The debug service allows you to use pprof to visualize and analyze profiling data.