### PR TITLE
cmd: Fix config loading for Redis

### DIFF
--- a/cmd/samproxy/main.go
+++ b/cmd/samproxy/main.go
@@ -62,7 +62,7 @@ func main() {
 	if opts.PeerType == "redis" || os.Getenv(config.RedisHostEnvVarName) != "" {
 		c = &config.RedisPeerFileConfig{}
 		c.(*config.RedisPeerFileConfig).ConfigFile = opts.ConfigFile
-		c.(*config.RedisPeerFileConfig).ConfigFile = opts.RulesFile
+		c.(*config.RedisPeerFileConfig).RulesFile = opts.RulesFile
 		err = c.(*config.RedisPeerFileConfig).Start()
 	} else {
 		c = &config.FileConfig{ConfigFile: opts.ConfigFile, RulesFile: opts.RulesFile}


### PR DESCRIPTION
A typo meant that it overwrote the "config" with the "rules" and failed
to start in Redis mode because `PeerListenAddr` was no longer set:

    panic: runtime error: index out of range [1] with length 1

    goroutine 1 [running]:
    github.com/honeycombio/samproxy/config.(*RedisPeerFileConfig).Start.func1()
            /go/src/github.com/honeycombio/samproxy/config/redis.go:122 +0x10b2
    sync.(*Once).doSlow(0xc00022a1a0, 0xc0000e7c20)
            /usr/local/go/src/sync/once.go:66 +0xec
    sync.(*Once).Do(...)
            /usr/local/go/src/sync/once.go:57
    github.com/honeycombio/samproxy/config.(*RedisPeerFileConfig).Start(0xc00022a000, 0xc00022a000, 0x1)
            /go/src/github.com/honeycombio/samproxy/config/redis.go:83 +0x9a
    main.main()
            /go/src/github.com/honeycombio/samproxy/cmd/samproxy/main.go:66 +0x249