### PR TITLE
gitignore: Allow the contents of cmd dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,6 @@
 *.out
 
 samproxy
+!/cmd/samproxy
 test_redimem
+!/cmd/test_redimem


### PR DESCRIPTION
The existing rules matched anything with `samproxy` or `test_redimem` in
the path, which meant that my editor (which reads `.gitignore`) wouldn't
allow me to find these files and that new files (however unlikely) in
these sub-directories of `cmd/` were never tracked.

Fix it by excluding the directories themselves but still preventing the
binaries from being committed to anywhere in the repo, in case they are
built to/from the wrong location.