### PR TITLE
collect: Fix SendDelay/TraceTimeout durations

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -357,10 +357,9 @@ func (i *InMemCollector) sendAfterTraceTimeout(trace *types.Trace) {
 	traceTimeout, err := i.Config.GetTraceTimeout()
 	if err != nil {
 		i.Logger.Errorf("failed to get trace timeout. pausing for 60 seconds")
-		traceTimeout = 60
+		traceTimeout = 60 * time.Second
 	}
-	dur := time.Duration(traceTimeout) * time.Second
-	go i.pauseAndSend(dur, trace)
+	go i.pauseAndSend(traceTimeout, trace)
 }
 
 // sendAfterRootDelay waits the SendDelay timeout then registers the trace to be
@@ -369,10 +368,9 @@ func (i *InMemCollector) sendAfterRootDelay(trace *types.Trace) {
 	sendDelay, err := i.Config.GetSendDelay()
 	if err != nil {
 		i.Logger.Errorf("failed to get send delay. pausing for 2 seconds")
-		sendDelay = 2
+		sendDelay = 2 * time.Second
 	}
-	dur := time.Duration(sendDelay) * time.Second
-	go i.pauseAndSend(dur, trace)
+	go i.pauseAndSend(sendDelay, trace)
 }
 
 // pauseAndSend will block for pause time and then send the trace.

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -23,7 +23,7 @@ func TestAddRootSpan(t *testing.T) {
 	transmission.Start()
 	conf := &config.MockConfig{
 		GetSendDelayVal:          0,
-		GetTraceTimeoutVal:       60,
+		GetTraceTimeoutVal:       60 * time.Second,
 		GetDefaultSamplerTypeVal: "DeterministicSampler",
 	}
 	coll := &InMemCollector{
@@ -98,7 +98,7 @@ func TestAddSpan(t *testing.T) {
 	transmission.Start()
 	conf := &config.MockConfig{
 		GetSendDelayVal:          0,
-		GetTraceTimeoutVal:       60,
+		GetTraceTimeoutVal:       60 * time.Second,
 		GetDefaultSamplerTypeVal: "DeterministicSampler",
 	}
 	coll := &InMemCollector{


### PR DESCRIPTION
The change to accept durations from the config in 272d899 meant that the
effective values were being multiplied by 1 billion. To achieve `1s` you
had to supply `1ns`. Fix this by using the durations directly.