### PR TITLE
metrics: Fix race in Prometheus start

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
@@ -18,6 +19,7 @@ type PromMetrics struct {
 	// metrics keeps a record of all the registered metrics so we can increment
 	// them by name
 	metrics map[string]interface{}
+	lock    sync.Mutex
 }
 
 type PromConfig struct {
@@ -63,7 +65,10 @@ func (p *PromMetrics) Register(name string, metricType string) {
 			Help: name,
 		})
 	}
+
+	p.lock.Lock()
 	p.metrics[name] = newmet
+	p.lock.Unlock()
 }
 
 func (p *PromMetrics) IncrementCounter(name string) {


### PR DESCRIPTION
We saw several crashes immediately after restarts which were caused by
metrics being registered and updating the same underlying map
concurrently:

    fatal error: concurrent map writes
    goroutine 100 [running]:
    runtime.throw(0xab0615, 0x15)
        /usr/local/go/src/runtime/panic.go:1116 +0x72 fp=0xc00006ae20 sp=0xc00006adf0 pc=0x435412
    runtime.mapassign_faststr(0x9fe6a0, 0xc000ac0270, 0xc000ab8000, 0x17, 0xc000ab8000)
        /usr/local/go/src/runtime/map_faststr.go:211 +0x3f7 fp=0xc00006ae88 sp=0xc00006ae20 pc=0x414cc7
    github.com/honeycombio/samproxy/metrics.(*PromMetrics).Register(0xc00009cf60, 0xc000ab8000, 0x17, 0xaa9ac3, 0x7)
        /go/src/github.com/honeycombio/samproxy/metrics/prometheus.go:66 +0xa4 fp=0xc00006af18 sp=0xc00006ae88 pc=0x95b834
    github.com/honeycombio/samproxy/route.(*Router).LnS(0xc00070c020, 0xaaa1ce, 0x8)
        /go/src/github.com/honeycombio/samproxy/route/route.go:89 +0x2cc fp=0xc00006afc8 sp=0xc00006af18 pc=0x96ee5c
    runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1373 +0x1 fp=0xc00006afd0 sp=0xc00006afc8 pc=0x465021
    created by github.com/honeycombio/samproxy/app.(*App).Start
        /go/src/github.com/honeycombio/samproxy/app/app.go:48 +0x21d

Fix by wrapping any writes to the map with a mutex lock. It doesn't feel
necessary to wrap the reads with `RWMutex` since they're already
checking if the key exists and it still wouldn't guard against a metric
being modified before it's registered.