### PR TITLE
Add some basic locking for transmission based tests

### DIFF
--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -71,8 +71,10 @@ func TestAddRootSpan(t *testing.T) {
 	// * create the trace in the cache
 	// * send the trace
 	assert.Equal(t, traceID1, coll.Cache.Get(traceID1).TraceID, "after adding the span, we should have a trace in the cache with the right trace ID")
+	transmission.Mux.RLock()
 	assert.Equal(t, 1, len(transmission.Events), "adding a root span should send the span")
 	assert.Equal(t, "aoeu", transmission.Events[0].Dataset, "sending a root span should immediately send that span via transmission")
+	transmission.Mux.RUnlock()
 
 	span = &types.Span{
 		TraceID: traceID2,
@@ -86,8 +88,10 @@ func TestAddRootSpan(t *testing.T) {
 	// * create the trace in the cache
 	// * send the trace
 	assert.Equal(t, traceID2, coll.Cache.Get(traceID2).TraceID, "after adding the span, we should have a trace in the cache with the right trace ID")
+	transmission.Mux.RLock()
 	assert.Equal(t, 2, len(transmission.Events), "adding another root span should send the span")
 	assert.Equal(t, "aoeu", transmission.Events[1].Dataset, "sending a root span should immediately send that span via transmission")
+	transmission.Mux.RUnlock()
 	coll.Stop()
 }
 
@@ -156,5 +160,7 @@ func TestAddSpan(t *testing.T) {
 	coll.AddSpan(rootSpan)
 	time.Sleep(conf.SendTickerVal * 2)
 	assert.Equal(t, 2, len(coll.Cache.Get(traceID).GetSpans()), "after adding a leaf and root span, we should have a two spans in the cache")
+	transmission.Mux.RLock()
 	assert.Equal(t, 2, len(transmission.Events), "adding a root span should send all spans in the trace")
+	transmission.Mux.RUnlock()
 }

--- a/transmit/mock.go
+++ b/transmit/mock.go
@@ -1,11 +1,14 @@
 package transmit
 
 import (
+	"sync"
+
 	"github.com/honeycombio/samproxy/types"
 )
 
 type MockTransmission struct {
 	Events []*types.Event
+	Mux    sync.RWMutex
 }
 
 func (m *MockTransmission) Start() error {
@@ -13,6 +16,16 @@ func (m *MockTransmission) Start() error {
 	return nil
 }
 
-func (m *MockTransmission) EnqueueEvent(ev *types.Event) { m.Events = append(m.Events, ev) }
-func (m *MockTransmission) EnqueueSpan(ev *types.Span)   { m.Events = append(m.Events, &ev.Event) }
-func (m *MockTransmission) Flush()                       {}
+func (m *MockTransmission) EnqueueEvent(ev *types.Event) {
+	m.Mux.Lock()
+	defer m.Mux.Unlock()
+	m.Events = append(m.Events, ev)
+}
+func (m *MockTransmission) EnqueueSpan(ev *types.Span) {
+	m.Mux.Lock()
+	defer m.Mux.Unlock()
+	m.Events = append(m.Events, &ev.Event)
+}
+func (m *MockTransmission) Flush() {
+
+}


### PR DESCRIPTION
Going through the race detector and fixing small locking issues. This will get us some of the way to running the tests in CI with the race detector on which seems like it would be highly useful.
