### PR TITLE
Fix config race condition in tests

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,16 +15,16 @@ func TestReload(t *testing.T) {
 	assert.Equal(t, nil, err)
 	defer os.RemoveAll(tmpDir)
 
-	f, err := ioutil.TempFile(tmpDir, "*.toml")
+	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
 	assert.Equal(t, nil, err)
 
 	dummy := []byte(`ListenAddr = "0.0.0.0:8080"`)
 
-	_, err = f.Write(dummy)
+	_, err = configFile.Write(dummy)
 	assert.Equal(t, nil, err)
-	f.Close()
+	configFile.Close()
 
-	c, err := NewConfig(f.Name(), f.Name())
+	c, err := NewConfig(configFile.Name(), configFile.Name())
 
 	if err != nil {
 		t.Error(err)
@@ -53,7 +53,7 @@ func TestReload(t *testing.T) {
 		}
 	}()
 
-	if file, err := os.OpenFile(f.Name(), os.O_RDWR, 0644); err == nil {
+	if file, err := os.OpenFile(configFile.Name(), os.O_RDWR, 0644); err == nil {
 		file.WriteString(`ListenAddr = "0.0.0.0:9000"`)
 		file.Close()
 	}
@@ -99,7 +99,7 @@ func TestGetSamplerTypes(t *testing.T) {
 	assert.Equal(t, nil, err)
 	defer os.RemoveAll(tmpDir)
 
-	f, err := ioutil.TempFile(tmpDir, "*.toml")
+	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
 	assert.Equal(t, nil, err)
 
 	dummyConfig := []byte(`
@@ -127,11 +127,11 @@ func TestGetSamplerTypes(t *testing.T) {
 		GoalSampleRate = 10
 `)
 
-	_, err = f.Write(dummyConfig)
+	_, err = rulesFile.Write(dummyConfig)
 	assert.Equal(t, nil, err)
-	f.Close()
+	rulesFile.Close()
 
-	c, err := NewConfig(f.Name(), f.Name())
+	c, err := NewConfig(rulesFile.Name(), rulesFile.Name())
 
 	if err != nil {
 		t.Error(err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,6 +15,9 @@ func TestReload(t *testing.T) {
 	assert.Equal(t, nil, err)
 	defer os.RemoveAll(tmpDir)
 
+	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	assert.Equal(t, nil, err)
+
 	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
 	assert.Equal(t, nil, err)
 
@@ -24,7 +27,7 @@ func TestReload(t *testing.T) {
 	assert.Equal(t, nil, err)
 	configFile.Close()
 
-	c, err := NewConfig(configFile.Name(), configFile.Name())
+	c, err := NewConfig(rulesFile.Name(), configFile.Name())
 
 	if err != nil {
 		t.Error(err)
@@ -99,6 +102,9 @@ func TestGetSamplerTypes(t *testing.T) {
 	assert.Equal(t, nil, err)
 	defer os.RemoveAll(tmpDir)
 
+	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	assert.Equal(t, nil, err)
+
 	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
 	assert.Equal(t, nil, err)
 
@@ -131,7 +137,7 @@ func TestGetSamplerTypes(t *testing.T) {
 	assert.Equal(t, nil, err)
 	rulesFile.Close()
 
-	c, err := NewConfig(rulesFile.Name(), rulesFile.Name())
+	c, err := NewConfig(configFile.Name(), rulesFile.Name())
 
 	if err != nil {
 		t.Error(err)

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -14,12 +14,12 @@ import (
 type fileConfig struct {
 	config    *viper.Viper
 	rules     *viper.Viper
-	conf      *confContents
+	conf      *configContents
 	callbacks []func()
 	mux       sync.Mutex
 }
 
-type confContents struct {
+type configContents struct {
 	ListenAddr              string
 	PeerListenAddr          string
 	APIKeys                 []string
@@ -70,7 +70,7 @@ func NewConfig(config, rules string) (Config, error) {
 	fc := &fileConfig{
 		config:    c,
 		rules:     r,
-		conf:      &confContents{},
+		conf:      &configContents{},
 		callbacks: make([]func(), 0),
 	}
 


### PR DESCRIPTION
If we are listening to the same file for changes then the watch event will fire twice and cause some race issues. Resolve this by creating the individual rules files