### PR TITLE
update docker build process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,7 @@ workflows:
       - docker/publish:
           context: Honeycomb Secrets
           tag: latest,${CIRCLE_TAG:1}
+          extra_build_args: --build-arg build_id=${CIRCLE_TAG:1}
           image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ workflows:
       - docker/publish:
           context: Honeycomb Secrets
           tag: latest,${CIRCLE_TAG:1}
-          extra_build_args: --build-arg build_id=${CIRCLE_TAG:1}
+          extra_build_args: --build-arg BUILD_ID=${CIRCLE_TAG:1}
           image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
           requires:
             - build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:alpine as builder
 
+RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
+
 ARG BUILD_ID=dev
 
 WORKDIR /app
@@ -16,7 +18,8 @@ RUN CGO_ENABLED=0 \
     GOARCH=amd64 \
     go build -ldflags "-X main.BuildID=${BUILD_ID}}" ./cmd/samproxy
 
-FROM alpine
+FROM scratch
 
-RUN apk add --update --no-cache ca-certificates
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
 COPY --from=builder /app/samproxy /usr/bin/samproxy

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 ADD go.mod go.sum ./
 
 RUN go mod download
+RUN go mod verify
 
 ADD . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,18 @@
-FROM golang:alpine
+FROM golang:1.14
 
-RUN apk add --update --no-cache git
-RUN go get github.com/honeycombio/samproxy/cmd/samproxy
+ARG BUILD_ID=dev
+
+WORKDIR /app
+
+ADD go.mod go.sum ./
+
+RUN go mod download
+
+ADD . .
+
+RUN go build -ldflags "-X main.BuildID=${BUILD_ID}}" ./cmd/samproxy
 
 FROM alpine
 
 RUN apk add --update --no-cache ca-certificates
-COPY --from=0 /go/bin/samproxy /usr/bin/samproxy
-
+COPY --from=0 /app/samproxy /usr/bin/samproxy

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ADD . .
 RUN CGO_ENABLED=0 \
     GOOS=linux \
     GOARCH=amd64 \
-    go build -ldflags "-X main.BuildID=${BUILD_ID}}" ./cmd/samproxy
+    go build -ldflags "-X main.BuildID=${BUILD_ID}" ./cmd/samproxy
 
 FROM scratch
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:alpine as builder
 
 ARG BUILD_ID=dev
 
@@ -19,4 +19,4 @@ RUN CGO_ENABLED=0 \
 FROM alpine
 
 RUN apk add --update --no-cache ca-certificates
-COPY --from=0 /app/samproxy /usr/bin/samproxy
+COPY --from=builder /app/samproxy /usr/bin/samproxy

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,10 @@ RUN go mod verify
 
 ADD . .
 
-RUN go build -ldflags "-X main.BuildID=${BUILD_ID}}" ./cmd/samproxy
+RUN CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64 \
+    go build -ldflags "-X main.BuildID=${BUILD_ID}}" ./cmd/samproxy
 
 FROM alpine
 


### PR DESCRIPTION
As per #95, the current docker setup does not work with go modules.

This changes the following things
- use go mod to fetch dependencies
- build samproxy from source
- use scratch as the final output image

We probably need to think about how we expect people to use this image as there a few other things we could do to improve/tighten this up
