### PR TITLE
Use viper to bind to the env variable redis host

### DIFF
--- a/cmd/samproxy/main.go
+++ b/cmd/samproxy/main.go
@@ -65,9 +65,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	host, _ := c.GetRedisHost()
+
 	var peers peer.Peers
 	// either the flag or the env var will kick us in to redis mode
-	if opts.PeerType == "redis" || os.Getenv(config.RedisHostEnvVarName) != "" {
+	if opts.PeerType == "redis" || host != "" {
 		peers, err = peer.NewRedisPeers(c)
 	} else {
 		peers = peer.NewFilePeers(c)

--- a/config/config.go
+++ b/config/config.go
@@ -2,10 +2,6 @@ package config
 
 import "time"
 
-const (
-	RedisHostEnvVarName = "SAMPROXY_REDIS_HOST"
-)
-
 // Config defines the interface the rest of the code uses to get items from the
 // config. There are different implementations of the config using different
 // backends to store the config. FileConfig is the default and uses a

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -51,6 +50,7 @@ type samplerConfigType struct {
 func NewConfig(config, rules string) (Config, error) {
 	c := viper.New()
 
+	c.BindEnv("redishost", "SAMPROXY_REDIS_HOST")
 	c.SetDefault("ListenAddr", "0.0.0.0:8080")
 	c.SetDefault("PeerListenAddr", "0.0.0.0:8081")
 	c.SetDefault("APIKeys", []string{"*"})
@@ -152,10 +152,6 @@ func (f *fileConfig) GetPeers() ([]string, error) {
 }
 
 func (f *fileConfig) GetRedisHost() (string, error) {
-	envRedisHost := os.Getenv(RedisHostEnvVarName)
-	if envRedisHost != "" {
-		return envRedisHost, nil
-	}
 	return f.conf.RedisHost, nil
 }
 


### PR DESCRIPTION
A small improvement I broke out of making the redis setup easier to use. We can use viper to preferentially use the env variable.