### PR TITLE
Fix `NewConfig` test parameters

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,7 +27,7 @@ func TestReload(t *testing.T) {
 	assert.Equal(t, nil, err)
 	configFile.Close()
 
-	c, err := NewConfig(rulesFile.Name(), configFile.Name())
+	c, err := NewConfig(configFile.Name(), rulesFile.Name())
 
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Use the correct file here, these should be the other way around. Not causing any broken tests right now but could certainly cause confusion in the future.