### PR TITLE
add PendingWorkCapacity to libhoney transmission

### DIFF
--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -69,10 +69,11 @@ func (h *HoneycombLogger) Start() error {
 	} else {
 		loggerTx = &transmission.Honeycomb{
 			// logs are often sent in flurries; flush every half second
-			MaxBatchSize:      100,
-			BatchTimeout:      500 * time.Millisecond,
-			UserAgentAddition: "samproxy/" + h.Version + " (metrics)",
-			Transport:         h.UpstreamTransport,
+			MaxBatchSize:        100,
+			BatchTimeout:        500 * time.Millisecond,
+			UserAgentAddition:   "samproxy/" + h.Version + " (metrics)",
+			Transport:           h.UpstreamTransport,
+			PendingWorkCapacity: libhoney.DefaultPendingWorkCapacity,
 		}
 	}
 


### PR DESCRIPTION
We were getting queue overflow errors from HoneycombLogger when starting up the app. The libhoney-go transmission uses [muster](https://godoc.org/github.com/facebookgo/muster). If you don't specify `PendingWorkCapacity` in the transmission, which becomes the capacity of muster's work channel, then the work channel becomes blocking and attempting to add the event to the queue fails: https://github.com/honeycombio/libhoney-go/blob/53a88e9cd3b91871ac547d3af1a195737295b7f9/transmission/transmission.go#L129