### PR TITLE
allow debug service address to be specified by config

### DIFF
--- a/cmd/samproxy/main.go
+++ b/cmd/samproxy/main.go
@@ -36,7 +36,7 @@ type Options struct {
 	ConfigFile string `short:"c" long:"config" description:"Path to config file" default:"/etc/samproxy/samproxy.toml"`
 	RulesFile  string `short:"r" long:"rules_config" description:"Path to rules config file" default:"/etc/samproxy/rules.toml"`
 	Version    bool   `short:"v" long:"version" description:"Print version number and exit"`
-	Debug      bool   `short:"d" long:"debug" description:"If enabled, runs debug service (runs on the first open port between 0.0.0.0:6060 and 0.0.0.0:6069 by default)"`
+	Debug      bool   `short:"d" long:"debug" description:"If enabled, runs debug service (runs on the first open port between localhost:6060 and :6069 by default)"`
 }
 
 func main() {

--- a/cmd/samproxy/main.go
+++ b/cmd/samproxy/main.go
@@ -174,7 +174,7 @@ func main() {
 	}
 
 	if opts.Debug {
-		err = g.Provide(&inject.Object{Value: &debug.DebugService{}})
+		err = g.Provide(&inject.Object{Value: &debug.DebugService{Config: c}})
 		if err != nil {
 			fmt.Printf("failed to provide injection graph. error: %+v\n", err)
 			os.Exit(1)

--- a/cmd/samproxy/main.go
+++ b/cmd/samproxy/main.go
@@ -36,7 +36,7 @@ type Options struct {
 	ConfigFile string `short:"c" long:"config" description:"Path to config file" default:"/etc/samproxy/samproxy.toml"`
 	RulesFile  string `short:"r" long:"rules_config" description:"Path to rules config file" default:"/etc/samproxy/rules.toml"`
 	Version    bool   `short:"v" long:"version" description:"Print version number and exit"`
-	Debug      bool   `short:"d" long:"debug" description:"If enabled, runs debug service (default port 6060)"`
+	Debug      bool   `short:"d" long:"debug" description:"If enabled, runs debug service (runs on the first open port between 0.0.0.0:6060 and 0.0.0.0:6069 by default)"`
 }
 
 func main() {

--- a/config/config.go
+++ b/config/config.go
@@ -94,6 +94,7 @@ type Config interface {
 	// GetSendTickerValue returns the duration to use to check for traces to send
 	GetSendTickerValue() time.Duration
 
-	// GetDebugServicePort sets the port the debug service will run on provided the -d command line flag // was specified
+	// GetDebugServicePort sets the port the debug service will run on (you must provide the
+	// command line flag -d to start the debug service)
 	GetDebugServicePort() string
 }

--- a/config/config.go
+++ b/config/config.go
@@ -93,4 +93,7 @@ type Config interface {
 
 	// GetSendTickerValue returns the duration to use to check for traces to send
 	GetSendTickerValue() time.Duration
+
+	// GetDebugServicePort sets the port the debug service will run on provided the -d command line flag // was specified
+	GetDebugServicePort() string
 }

--- a/config/config.go
+++ b/config/config.go
@@ -94,7 +94,7 @@ type Config interface {
 	// GetSendTickerValue returns the duration to use to check for traces to send
 	GetSendTickerValue() time.Duration
 
-	// GetDebugServicePort sets the port the debug service will run on (you must provide the
+	// GetDebugServiceAddr sets the IP and port the debug service will run on (you must provide the
 	// command line flag -d to start the debug service)
-	GetDebugServicePort() string
+	GetDebugServiceAddr() string
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -142,6 +142,28 @@ func TestPeerManagementType(t *testing.T) {
 	}
 }
 
+func TestDebugServicePort(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	assert.Equal(t, nil, err)
+	defer os.RemoveAll(tmpDir)
+
+	configFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	assert.Equal(t, nil, err)
+
+	rulesFile, err := ioutil.TempFile(tmpDir, "*.toml")
+	assert.Equal(t, nil, err)
+
+	_, err = configFile.Write([]byte(`
+	DebugServicePort = "8085"
+	`))
+
+	c, err := NewConfig(configFile.Name(), rulesFile.Name())
+
+	if d := c.GetDebugServicePort(); d != "8085" {
+		t.Error("received", d, "expected", "8085")
+	}
+}
+
 func TestGetSamplerTypes(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "")
 	assert.Equal(t, nil, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -154,13 +154,13 @@ func TestDebugServiceAddr(t *testing.T) {
 	assert.Equal(t, nil, err)
 
 	_, err = configFile.Write([]byte(`
-	DebugServiceAddr = "0.0.0.0:8085"
+	DebugServiceAddr = "localhost:8085"
 	`))
 
 	c, err := NewConfig(configFile.Name(), rulesFile.Name())
 
-	if d := c.GetDebugServiceAddr(); d != "0.0.0.0:8085" {
-		t.Error("received", d, "expected", "0.0.0.0:8085")
+	if d := c.GetDebugServiceAddr(); d != "localhost:8085" {
+		t.Error("received", d, "expected", "localhost:8085")
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -142,7 +142,7 @@ func TestPeerManagementType(t *testing.T) {
 	}
 }
 
-func TestDebugServicePort(t *testing.T) {
+func TestDebugServiceAddr(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "")
 	assert.Equal(t, nil, err)
 	defer os.RemoveAll(tmpDir)
@@ -154,13 +154,13 @@ func TestDebugServicePort(t *testing.T) {
 	assert.Equal(t, nil, err)
 
 	_, err = configFile.Write([]byte(`
-	DebugServicePort = "8085"
+	DebugServiceAddr = "0.0.0.0:8085"
 	`))
 
 	c, err := NewConfig(configFile.Name(), rulesFile.Name())
 
-	if d := c.GetDebugServicePort(); d != "8085" {
-		t.Error("received", d, "expected", "8085")
+	if d := c.GetDebugServiceAddr(); d != "0.0.0.0:8085" {
+		t.Error("received", d, "expected", "0.0.0.0:8085")
 	}
 }
 

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -33,6 +33,7 @@ type configContents struct {
 	SendTicker         time.Duration
 	UpstreamBufferSize int
 	PeerBufferSize     int
+	DebugServicePort   string
 }
 
 // Used to marshall in the sampler type in SamplerConfig definitions
@@ -235,4 +236,8 @@ func (f *fileConfig) GetPeerBufferSize() int {
 
 func (f *fileConfig) GetSendTickerValue() time.Duration {
 	return f.conf.SendTicker
+}
+
+func (f *fileConfig) GetDebugServicePort() string {
+	return f.conf.DebugServicePort
 }

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -33,7 +33,7 @@ type configContents struct {
 	SendTicker         time.Duration
 	UpstreamBufferSize int
 	PeerBufferSize     int
-	DebugServicePort   string
+	DebugServiceAddr   string
 }
 
 // Used to marshall in the sampler type in SamplerConfig definitions
@@ -238,6 +238,6 @@ func (f *fileConfig) GetSendTickerValue() time.Duration {
 	return f.conf.SendTicker
 }
 
-func (f *fileConfig) GetDebugServicePort() string {
-	return f.conf.DebugServicePort
+func (f *fileConfig) GetDebugServiceAddr() string {
+	return f.conf.DebugServiceAddr
 }

--- a/config/mock.go
+++ b/config/mock.go
@@ -44,7 +44,7 @@ type MockConfig struct {
 	UseIPV6Identifier        bool
 	RedisIdentifier          string
 	PeerManagementType       string
-	DebugServicePort         string
+	DebugServiceAddr         string
 }
 
 func (m *MockConfig) ReloadConfig()                 {}
@@ -118,6 +118,6 @@ func (m *MockConfig) GetPeerManagementType() (string, error) {
 	return m.PeerManagementType, nil
 }
 
-func (m *MockConfig) GetDebugServicePort() string {
-	return m.DebugServicePort
+func (m *MockConfig) GetDebugServiceAddr() string {
+	return m.DebugServiceAddr
 }

--- a/config/mock.go
+++ b/config/mock.go
@@ -44,6 +44,7 @@ type MockConfig struct {
 	UseIPV6Identifier        bool
 	RedisIdentifier          string
 	PeerManagementType       string
+	DebugServicePort         string
 }
 
 func (m *MockConfig) ReloadConfig()                 {}
@@ -115,4 +116,8 @@ func (m *MockConfig) GetSendTickerValue() time.Duration {
 
 func (m *MockConfig) GetPeerManagementType() (string, error) {
 	return m.PeerManagementType, nil
+}
+
+func (m *MockConfig) GetDebugServicePort() string {
+	return m.DebugServicePort
 }

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -67,6 +67,11 @@ LoggingLevel = "debug"
 UpstreamBufferSize = 10000
 PeerBufferSize = 10000
 
+# DebugServicePort sets the port the debug service will run on
+# The debug service will only run if the command line flag -d is specified
+# The debug service runs on the first open port between 6060 and 6069 if no port is specified
+# DebugServicePort = "6060"
+
 ############################
 ## Implementation Choices ##
 ############################

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -67,10 +67,10 @@ LoggingLevel = "debug"
 UpstreamBufferSize = 10000
 PeerBufferSize = 10000
 
-# DebugServicePort sets the port the debug service will run on
+# DebugServiceAddr sets the IP and port the debug service will run on
 # The debug service will only run if the command line flag -d is specified
-# The debug service runs on the first open port between 6060 and 6069 if no port is specified
-# DebugServicePort = "6060"
+# The debug service runs on the first open port between 0.0.0.0:6060 and 0.0.0.0:6069 by default
+# DebugServiceAddr = "0.0.0.0:8085"
 
 ############################
 ## Implementation Choices ##

--- a/config_complete.toml
+++ b/config_complete.toml
@@ -69,8 +69,8 @@ PeerBufferSize = 10000
 
 # DebugServiceAddr sets the IP and port the debug service will run on
 # The debug service will only run if the command line flag -d is specified
-# The debug service runs on the first open port between 0.0.0.0:6060 and 0.0.0.0:6069 by default
-# DebugServiceAddr = "0.0.0.0:8085"
+# The debug service runs on the first open port between localhost:6060 and :6069 by default
+# DebugServiceAddr = "localhost:8085"
 
 ############################
 ## Implementation Choices ##

--- a/service/debug/debug_service.go
+++ b/service/debug/debug_service.go
@@ -50,9 +50,9 @@ func (s *DebugService) Start() error {
 	s.Publish("memstats", Func(memstats))
 
 	go func() {
-		defaultAddr := s.Config.GetDebugServiceAddr()
-		if defaultAddr != "" {
-			host, portStr, _ := net.SplitHostPort(defaultAddr)
+		configAddr := s.Config.GetDebugServiceAddr()
+		if configAddr != "" {
+			host, portStr, _ := net.SplitHostPort(configAddr)
 			addr := net.JoinHostPort(host, portStr)
 			logrus.Infof("Debug service listening on %s", addr)
 

--- a/service/debug/debug_service.go
+++ b/service/debug/debug_service.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/honeycombio/samproxy/config"
 	metrics "github.com/rcrowley/go-metrics"
 	"github.com/rcrowley/go-metrics/exp"
 	"github.com/sirupsen/logrus"
@@ -27,6 +28,7 @@ type DebugService struct {
 	urls    []string
 	expVars map[string]interface{}
 	mutex   sync.RWMutex
+	Config  config.Config
 }
 
 func (s *DebugService) Start() error {
@@ -48,28 +50,37 @@ func (s *DebugService) Start() error {
 	s.Publish("memstats", Func(memstats))
 
 	go func() {
-		// Prefer to listen on addr, but will try to bind to the next 9 ports
-		// in case you have multiple services running on the same host.
-		for i := 0; i < 10; i++ {
-			host, portStr, _ := net.SplitHostPort(addr)
-			port, _ := strconv.Atoi(portStr)
-			port += i
-			addr := net.JoinHostPort(host, fmt.Sprint(port))
-
+		defaultPort := s.Config.GetDebugServicePort()
+		if defaultPort != "" {
+			addr := net.JoinHostPort("localhost", defaultPort)
 			logrus.Infof("Debug service listening on %s", addr)
 
 			err := http.ListenAndServe(addr, s.mux)
 			logrus.WithError(err).Warn("debug http server error")
+		} else {
+			// Prefer to listen on addr, but will try to bind to the next 9 ports
+			// in case you have multiple services running on the same host.
+			for i := 0; i < 10; i++ {
+				host, portStr, _ := net.SplitHostPort(addr)
+				port, _ := strconv.Atoi(portStr)
+				port += i
+				addr := net.JoinHostPort(host, fmt.Sprint(port))
 
-			if err, ok := err.(*net.OpError); ok {
-				if err, ok := err.Err.(*os.SyscallError); ok {
-					if err.Err == syscall.EADDRINUSE {
-						// address already in use, try another
-						continue
+				logrus.Infof("Debug service listening on %s", addr)
+
+				err := http.ListenAndServe(addr, s.mux)
+				logrus.WithError(err).Warn("debug http server error")
+
+				if err, ok := err.(*net.OpError); ok {
+					if err, ok := err.Err.(*os.SyscallError); ok {
+						if err.Err == syscall.EADDRINUSE {
+							// address already in use, try another
+							continue
+						}
 					}
 				}
+				break
 			}
-			break
 		}
 	}()
 

--- a/service/debug/debug_service.go
+++ b/service/debug/debug_service.go
@@ -50,9 +50,10 @@ func (s *DebugService) Start() error {
 	s.Publish("memstats", Func(memstats))
 
 	go func() {
-		defaultPort := s.Config.GetDebugServicePort()
-		if defaultPort != "" {
-			addr := net.JoinHostPort("localhost", defaultPort)
+		defaultAddr := s.Config.GetDebugServiceAddr()
+		if defaultAddr != "" {
+			host, portStr, _ := net.SplitHostPort(defaultAddr)
+			addr := net.JoinHostPort(host, portStr)
 			logrus.Infof("Debug service listening on %s", addr)
 
 			err := http.ListenAndServe(addr, s.mux)


### PR DESCRIPTION
I tested this locally both by specifying the debug service address in config, and allowing it to choose it's own.