### PR TITLE
Add msgpack support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/klauspost/compress v1.10.3
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/pelletier/go-toml v1.8.0 // indirect
+	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0
@@ -28,6 +29,8 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.5.1
+	github.com/tinylib/msgp v1.1.2
+	github.com/vmihailenco/msgpack/v4 v4.3.11
 	golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6 // indirect
 	golang.org/x/text v0.3.3 // indirect
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,8 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.0 h1:Keo9qb7iRJs2voHvunFtuuYFsbWeOBh8/P9v/kVMFtw=
 github.com/pelletier/go-toml v1.8.0/go.mod h1:D6yutnOGMveHEPV7VQOuvI/gXY61bv+9bAOTRnLElKs=
+github.com/philhofer/fwd v1.0.0 h1:UbZqGr5Y38ApvM/V/jEljVxwocdweyH+vmYvRPBnbqQ=
+github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
@@ -245,6 +247,8 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/tinylib/msgp v1.1.2 h1:gWmO7n0Ys2RBEb7GPYB9Ujq8Mk5p2U08lRnmMcGy6BQ=
+github.com/tinylib/msgp v1.1.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/vmihailenco/msgpack/v4 v4.3.11 h1:Q47CePddpNGNhk4GCnAx9DDtASi2rasatE0cd26cZoE=
 github.com/vmihailenco/msgpack/v4 v4.3.11/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=

--- a/route/route.go
+++ b/route/route.go
@@ -160,7 +160,7 @@ func (r *Router) event(w http.ResponseWriter, req *http.Request) {
 	reqBod, _ := ioutil.ReadAll(req.Body)
 	var trEv eventWithTraceID
 	// pull out just the trace ID for use in routing
-	err := unmarshal(reqBod, &trEv)
+	err := unmarshal(req, reqBod, &trEv)
 	if err != nil {
 		logger.WithField("error", err.Error()).WithField("request.url", req.URL).WithField("json_body", string(reqBod)).Debugf("error parsing json")
 		r.handlerReturnWithError(w, ErrJSONFailed, err)
@@ -274,7 +274,7 @@ func (r *Router) requestToEvent(req *http.Request, reqBod []byte) (*types.Event,
 		return nil, err
 	}
 	data := map[string]interface{}{}
-	err = unmarshal(reqBod, &data)
+	err = unmarshal(req, reqBod, &data)
 	if err != nil {
 		return nil, err
 	}
@@ -311,7 +311,7 @@ func (r *Router) batch(w http.ResponseWriter, req *http.Request) {
 
 	batchedEvents := make([]batchedEvent, 0)
 	batchedResponses := make([]*BatchResponse, 0)
-	err = unmarshal(reqBod, &batchedEvents)
+	err = unmarshal(req, reqBod, &batchedEvents)
 	if err != nil {
 		logger.WithField("error", err.Error()).WithField("request.url", req.URL).WithField("json_body", string(reqBod)).Debugf("error parsing json")
 		r.handlerReturnWithError(w, ErrJSONFailed, err)
@@ -558,6 +558,6 @@ func makeDecoders(num int) (chan *zstd.Decoder, error) {
 	return zstdDecoders, nil
 }
 
-func unmarshal(data []byte, v interface{}) error {
+func unmarshal(r *http.Request, data []byte, v interface{}) error {
 	return json.Unmarshal(data, v)
 }

--- a/route/route.go
+++ b/route/route.go
@@ -572,6 +572,8 @@ func makeDecoders(num int) (chan *zstd.Decoder, error) {
 func unmarshal(r *http.Request, data io.Reader, v interface{}) error {
 	switch r.Header.Get("Content-Type") {
 	case "application/x-msgpack", "application/msgpack":
+		// First try to decode with the fast but fussy msgp. If that fails,
+		// defer to the much more friendly msgpack.
 		if decodable, ok := v.(msgp.Decodable); ok {
 			err := msgp.Decode(data, decodable)
 

--- a/route/route.go
+++ b/route/route.go
@@ -504,17 +504,17 @@ func (r *Router) batchedEventToEvent(req *http.Request, bev batchedEvent) (*type
 
 type batchedEvent struct {
 	Timestamp        string                 `json:"time"`
-	MsgPackTimestamp time.Time              `msgpack:"time"`
+	MsgPackTimestamp *time.Time             `msgpack:"time,omitempty"`
 	SampleRate       int64                  `json:"samplerate" msgpack:"samplerate"`
 	Data             map[string]interface{} `json:"data" msgpack:"data"`
 }
 
 func (b *batchedEvent) getEventTime() time.Time {
-	if b.MsgPackTimestamp.IsZero() {
-		return getEventTime(b.Timestamp)
+	if b.MsgPackTimestamp != nil {
+		return *b.MsgPackTimestamp
 	}
 
-	return b.MsgPackTimestamp
+	return getEventTime(b.Timestamp)
 }
 
 // getEventTime tries to guess the time format in our time header!

--- a/route/route.go
+++ b/route/route.go
@@ -160,7 +160,7 @@ func (r *Router) event(w http.ResponseWriter, req *http.Request) {
 	reqBod, _ := ioutil.ReadAll(req.Body)
 	var trEv eventWithTraceID
 	// pull out just the trace ID for use in routing
-	err := json.Unmarshal(reqBod, &trEv)
+	err := unmarshal(reqBod, &trEv)
 	if err != nil {
 		logger.WithField("error", err.Error()).WithField("request.url", req.URL).WithField("json_body", string(reqBod)).Debugf("error parsing json")
 		r.handlerReturnWithError(w, ErrJSONFailed, err)
@@ -274,7 +274,7 @@ func (r *Router) requestToEvent(req *http.Request, reqBod []byte) (*types.Event,
 		return nil, err
 	}
 	data := map[string]interface{}{}
-	err = json.Unmarshal(reqBod, &data)
+	err = unmarshal(reqBod, &data)
 	if err != nil {
 		return nil, err
 	}
@@ -311,7 +311,7 @@ func (r *Router) batch(w http.ResponseWriter, req *http.Request) {
 
 	batchedEvents := make([]batchedEvent, 0)
 	batchedResponses := make([]*BatchResponse, 0)
-	err = json.Unmarshal(reqBod, &batchedEvents)
+	err = unmarshal(reqBod, &batchedEvents)
 	if err != nil {
 		logger.WithField("error", err.Error()).WithField("request.url", req.URL).WithField("json_body", string(reqBod)).Debugf("error parsing json")
 		r.handlerReturnWithError(w, ErrJSONFailed, err)
@@ -556,4 +556,8 @@ func makeDecoders(num int) (chan *zstd.Decoder, error) {
 		zstdDecoders <- zReader
 	}
 	return zstdDecoders, nil
+}
+
+func unmarshal(data []byte, v interface{}) error {
+	return json.Unmarshal(data, v)
 }

--- a/route/route.go
+++ b/route/route.go
@@ -577,7 +577,7 @@ func unmarshal(r *http.Request, data io.Reader, v interface{}) error {
 		if decodable, ok := v.(msgp.Decodable); ok {
 			err := msgp.Decode(data, decodable)
 
-			if err != nil {
+			if err == nil {
 				return nil
 			}
 		}

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -98,6 +98,7 @@ func unmarshalRequest(w *httptest.ResponseRecorder, content string, body io.Read
 
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(err.Error()))
 			return
 		}
 

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -119,7 +119,7 @@ func TestUnmarshal(t *testing.T) {
 	unmarshalRequest(w, "nope", body)
 
 	if w.Code != http.StatusBadRequest {
-		t.Error("Expecting BadRequest")
+		t.Error("Expecting", http.StatusBadRequest, "Received", w.Code)
 	}
 
 	w = httptest.NewRecorder()

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -3,6 +3,7 @@ package route
 import (
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -135,6 +136,7 @@ func unmarshalBatchRequest(w *httptest.ResponseRecorder, content string, body io
 func TestUnmarshal(t *testing.T) {
 	var w *httptest.ResponseRecorder
 	var body io.Reader
+	now := time.Now()
 
 	w = httptest.NewRecorder()
 	body = bytes.NewBufferString("")
@@ -158,6 +160,14 @@ func TestUnmarshal(t *testing.T) {
 
 	if b := w.Body.String(); b != "test" {
 		t.Error("Expecting test")
+	}
+
+	w = httptest.NewRecorder()
+	body = bytes.NewBufferString(fmt.Sprintf(`{"time": "%s"}`, now.Format(time.RFC3339Nano)))
+	unmarshalBatchRequest(w, "application/json", body)
+
+	if b := w.Body.String(); b != now.Format(time.RFC3339Nano) {
+		t.Error("Expecting", now, "Received", b)
 	}
 
 	var buf *bytes.Buffer
@@ -199,7 +209,6 @@ func TestUnmarshal(t *testing.T) {
 		t.Error("Expecting test")
 	}
 
-	now := time.Now()
 	w = httptest.NewRecorder()
 	buf = &bytes.Buffer{}
 	e = msgpack.NewEncoder(buf)

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -162,13 +162,13 @@ func TestUnmarshal(t *testing.T) {
 
 	var buf *bytes.Buffer
 	var e *msgpack.Encoder
-	var in map[string]string
+	var in map[string]interface{}
 	var err error
 
 	w = httptest.NewRecorder()
 	buf = &bytes.Buffer{}
 	e = msgpack.NewEncoder(buf)
-	in = map[string]string{"trace.trace_id": "test"}
+	in = map[string]interface{}{"trace.trace_id": "test"}
 	err = e.Encode(in)
 
 	if err != nil {
@@ -185,7 +185,7 @@ func TestUnmarshal(t *testing.T) {
 	w = httptest.NewRecorder()
 	buf = &bytes.Buffer{}
 	e = msgpack.NewEncoder(buf)
-	in = map[string]string{"traceId": "test"}
+	in = map[string]interface{}{"traceId": "test"}
 	err = e.Encode(in)
 
 	if err != nil {
@@ -203,8 +203,8 @@ func TestUnmarshal(t *testing.T) {
 	w = httptest.NewRecorder()
 	buf = &bytes.Buffer{}
 	e = msgpack.NewEncoder(buf)
-	inz := map[string]interface{}{"time": now}
-	err = e.Encode(inz)
+	in = map[string]interface{}{"time": now}
+	err = e.Encode(in)
 
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Adds support for msgpack encoded events/batches. 

Supports the same `Content-Type` headers that our API does.

Although there are unit tests to cover this new unmarshal method, some manual testing as part of the review would be great, as we have minimal coverage on code outside of this new test 😬