### PR TITLE
Use SHA when tag is not specified

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
       - run: |
           GOOS=<< parameters.os >> \
           GOARCH=<< parameters.arch >> \
-          go build -ldflags "-X main.BuildID=${CIRCLE_TAG}" \
+          go build -ldflags "-X main.BuildID=${CIRCLE_TAG:-${CIRCLE_SHA1:7}}" \
           -o $GOPATH/bin/samproxy-<< parameters.os >>-<< parameters.arch >> \
           ./cmd/samproxy
 
@@ -74,13 +74,13 @@ jobs:
       - run: mkdir -p ~/artifacts
       - run:
           name: build_deb_amd64
-          command: ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG}" -t deb && mv *.deb ~/artifacts
+          command: ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG:-${CIRCLE_SHA1:7}}" -t deb && mv *.deb ~/artifacts
       - run:
           name: build_deb_arm64
-          command: ./build-pkg.sh -m arm64 -v "${CIRCLE_TAG}" -t deb && mv *.deb ~/artifacts
+          command: ./build-pkg.sh -m arm64 -v "${CIRCLE_TAG:-${CIRCLE_SHA1:7}}" -t deb && mv *.deb ~/artifacts
       - run:
           name: build_rpm_amd64
-          command: ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG}" -t rpm && mv *.rpm ~/artifacts
+          command: ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG:-${CIRCLE_SHA1:7}}" -t rpm && mv *.rpm ~/artifacts
       - run:
           name: copy_binaries
           command: cp $GOPATH/bin/samproxy-* ~/artifacts
@@ -117,7 +117,7 @@ jobs:
           aws-region: AWS_REGION
       - run:
           name: sync_s3_artifacts
-          command: aws s3 sync ~/artifacts s3://honeycomb-builds/honeycombio/samproxy/${CIRCLE_TAG}/
+          command: aws s3 sync ~/artifacts s3://honeycomb-builds/honeycombio/samproxy/${CIRCLE_TAG:-${CIRCLE_SHA1:7}}/
 
 workflows:
   build:
@@ -147,9 +147,7 @@ workflows:
             - build
           filters:
             tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
+              only: /.*/
       - docker/publish:
           tag: latest,${CIRCLE_TAG:1}
           extra_build_args: --build-arg BUILD_ID=${CIRCLE_TAG:1}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
       - run: |
           GOOS=<< parameters.os >> \
           GOARCH=<< parameters.arch >> \
-          go build -ldflags "-X main.BuildID=${CIRCLE_TAG:-${CIRCLE_SHA1:7}}" \
+          go build -ldflags "-X main.BuildID=${CIRCLE_TAG:-${CIRCLE_SHA1:0:7}}" \
           -o $GOPATH/bin/samproxy-<< parameters.os >>-<< parameters.arch >> \
           ./cmd/samproxy
 
@@ -74,13 +74,13 @@ jobs:
       - run: mkdir -p ~/artifacts
       - run:
           name: build_deb_amd64
-          command: ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG:-${CIRCLE_SHA1:7}}" -t deb && mv *.deb ~/artifacts
+          command: ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG:-${CIRCLE_SHA1:0:7}}" -t deb && mv *.deb ~/artifacts
       - run:
           name: build_deb_arm64
-          command: ./build-pkg.sh -m arm64 -v "${CIRCLE_TAG:-${CIRCLE_SHA1:7}}" -t deb && mv *.deb ~/artifacts
+          command: ./build-pkg.sh -m arm64 -v "${CIRCLE_TAG:-${CIRCLE_SHA1:0:7}}" -t deb && mv *.deb ~/artifacts
       - run:
           name: build_rpm_amd64
-          command: ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG:-${CIRCLE_SHA1:7}}" -t rpm && mv *.rpm ~/artifacts
+          command: ./build-pkg.sh -m amd64 -v "${CIRCLE_TAG:-${CIRCLE_SHA1:0:7}}" -t rpm && mv *.rpm ~/artifacts
       - run:
           name: copy_binaries
           command: cp $GOPATH/bin/samproxy-* ~/artifacts
@@ -117,7 +117,7 @@ jobs:
           aws-region: AWS_REGION
       - run:
           name: sync_s3_artifacts
-          command: aws s3 sync ~/artifacts s3://honeycomb-builds/honeycombio/samproxy/${CIRCLE_TAG:-${CIRCLE_SHA1:7}}/
+          command: aws s3 sync ~/artifacts s3://honeycomb-builds/honeycombio/samproxy/${CIRCLE_TAG:-${CIRCLE_SHA1:0:7}}/
 
 workflows:
   build:


### PR DESCRIPTION
Changes a couple of things:

- always push builds to S3
- if no tag is specified then use the SHA for the current commit