### PR TITLE
Update to latest aws-cli orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  aws-cli: circleci/aws-cli@0.1.13
+  aws-cli: circleci/aws-cli@1.3.0
   docker: circleci/docker@1.3.0
 
 executors:
@@ -110,8 +110,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - aws-cli/install
-      - aws-cli/configure:
+      - aws-cli/setup:
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY
           aws-region: AWS_REGION


### PR DESCRIPTION
I noticed that we were using a very old version of the orb that was using an old deprecated version of python. Updated to the latest new shiny