### PR TITLE
Log panic stack traces

### DIFF
--- a/route/errors.go
+++ b/route/errors.go
@@ -38,11 +38,15 @@ func (r *Router) handlerReturnWithError(w http.ResponseWriter, he handlerError, 
 	if err != nil {
 		he.err = err
 	}
-	r.Logger.WithFields(map[string]interface{}{
+
+	fields := map[string]interface{}{
 		"error.err":         he.err.Error(),
 		"error.msg":         he.msg,
 		"error.status_code": he.status,
-	}).Errorf("handler returning error")
+	}
+
+	r.Logger.WithFields(fields).Errorf("handler returning error")
+
 	w.WriteHeader(he.status)
 
 	errmsg := he.msg

--- a/route/errors.go
+++ b/route/errors.go
@@ -3,6 +3,7 @@ package route
 import (
 	"fmt"
 	"net/http"
+	"runtime/debug"
 )
 
 type handlerError struct {
@@ -43,6 +44,12 @@ func (r *Router) handlerReturnWithError(w http.ResponseWriter, he handlerError, 
 		"error.err":         he.err.Error(),
 		"error.msg":         he.msg,
 		"error.status_code": he.status,
+	}
+
+	// this is a little jank but should work for now, we might want to rethink
+	// how this section of the code works to make this nicer
+	if he.msg == ErrCaughtPanic.msg {
+		fields["error.stack_trace"] = string(debug.Stack())
 	}
 
 	r.Logger.WithFields(fields).Errorf("handler returning error")

--- a/route/errors.go
+++ b/route/errors.go
@@ -44,13 +44,18 @@ func (r *Router) handlerReturnWithError(w http.ResponseWriter, he handlerError, 
 		"error.status_code": he.status,
 	}).Errorf("handler returning error")
 	w.WriteHeader(he.status)
+
 	errmsg := he.msg
+
 	if he.detailed {
 		errmsg = fmt.Sprintf(he.msg + ": " + he.err.Error())
 	}
+
 	if !he.friendly {
 		errmsg = ErrGenericMessage
 	}
+
 	jsonErrMsg := []byte(`{"source":"samproxy","error":"` + errmsg + `"}`)
+
 	w.Write(jsonErrMsg)
 }

--- a/route/errors_test.go
+++ b/route/errors_test.go
@@ -1,0 +1,36 @@
+package route
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/honeycombio/samproxy/logger"
+)
+
+func TestHandlerReturnWithError(t *testing.T) {
+	var w *httptest.ResponseRecorder
+	var l *logger.MockLogger
+	var router *Router
+
+	l = &logger.MockLogger{}
+	router = &Router{
+		Logger: l,
+	}
+
+	w = httptest.NewRecorder()
+	http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		router.handlerReturnWithError(w, ErrCaughtPanic, errors.New("oh no"))
+	}).ServeHTTP(w, &http.Request{})
+
+	if len(l.Events) != 1 {
+		t.Fail()
+	}
+
+	e := l.Events[0]
+
+	if _, ok := e.Fields["error.stack_trace"]; !ok {
+		t.Error("expected fields to contain error.stack_trace", e.Fields)
+	}
+}

--- a/route/middleware.go
+++ b/route/middleware.go
@@ -65,7 +65,13 @@ func (r *Router) panicCatcher(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer func() {
 			if rcvr := recover(); rcvr != nil {
-				r.handlerReturnWithError(w, ErrCaughtPanic, fmt.Errorf("caught panic: %v", rcvr))
+				err, ok := rcvr.(error)
+
+				if !ok {
+					err = fmt.Errorf("caught panic: %v", rcvr)
+				}
+
+				r.handlerReturnWithError(w, ErrCaughtPanic, err)
 			}
 		}()
 		next.ServeHTTP(w, req)


### PR DESCRIPTION
Relies on #121 and resolves #62

Adds the stack to the logger if we have passed in a `ErrCaughtPanic` to the function. The method for determining this is a little jank but I think is good enough for now. We can make a ticket to improve how this works