### PR TITLE
avoid allocations for unused log entries

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -29,7 +29,7 @@ type App struct {
 // Start exits, Stop will be called on all dependencies then on App then the
 // program will exit.
 func (a *App) Start() error {
-	a.Logger.Debugf("Starting up App...")
+	a.Logger.Debug().Logf("Starting up App...")
 
 	// set up signal channel to exit
 	sigsToExit := make(chan os.Signal, 1)
@@ -45,12 +45,12 @@ func (a *App) Start() error {
 
 	// block on our signal handler to exit
 	sig := <-sigsToExit
-	a.Logger.Errorf("Caught signal \"%s\"", sig)
+	a.Logger.Error().Logf("Caught signal \"%s\"", sig)
 
 	return nil
 }
 
 func (a *App) Stop() error {
-	a.Logger.Debugf("Shutting down App...")
+	a.Logger.Debug().Logf("Shutting down App...")
 	return nil
 }

--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -40,8 +40,8 @@ type CacheConfig struct {
 const DefaultInMemCacheCapacity = 10000
 
 func (d *DefaultInMemCache) Start() error {
-	d.Logger.Debugf("Starting DefaultInMemCache")
-	defer func() { d.Logger.Debugf("Finished starting DefaultInMemCache") }()
+	d.Logger.Debug().Logf("Starting DefaultInMemCache")
+	defer func() { d.Logger.Debug().Logf("Finished starting DefaultInMemCache") }()
 	if d.Config.CacheCapacity == 0 {
 		d.Config.CacheCapacity = DefaultInMemCacheCapacity
 	}

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -415,9 +415,9 @@ func (i *InMemCollector) send(trace *types.Trace) {
 
 	// ok, we're not dropping this trace; send all the spans
 	if i.Config.GetIsDryRun() && !shouldSend {
-		i.Logger.Info().WithField("trace_id", trace.TraceID).WithField("dataset", trace.Dataset).Logf("Trace would have been dropped, but dry run mode is enabled")
+		i.Logger.Info().WithField("trace_id", &trace.TraceID).WithField("dataset", &trace.Dataset).Logf("Trace would have been dropped, but dry run mode is enabled")
 	}
-	i.Logger.Info().WithField("trace_id", trace.TraceID).WithField("dataset", trace.Dataset).Logf("Sending trace to dataset")
+	i.Logger.Info().WithField("trace_id", &trace.TraceID).WithField("dataset", &trace.Dataset).Logf("Sending trace to dataset")
 	for _, sp := range trace.GetSpans() {
 		if sp.SampleRate < 1 {
 			sp.SampleRate = 1

--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -126,7 +126,7 @@ func (h *HoneycombLogger) readResponses() {
 }
 
 func (h *HoneycombLogger) reloadBuilder() {
-	h.Debugf("reloading config for Honeycomb logger")
+	h.Debug().Logf("reloading config for Honeycomb logger")
 	// preseve log level
 	logLevel := h.loggerConfig.level
 	loggerConfig := HoneycombLoggerConfig{}
@@ -135,7 +135,7 @@ func (h *HoneycombLogger) reloadBuilder() {
 		// complain about this both to STDOUT and to the previously configured
 		// honeycomb logger
 		fmt.Printf("failed to reload configs for Honeycomb logger: %+v\n", err)
-		h.Errorf("failed to reload configs for Honeycomb logger: %+v", err)
+		h.Error().Logf("failed to reload configs for Honeycomb logger: %+v", err)
 		return
 	}
 	loggerConfig.level = logLevel
@@ -151,64 +151,46 @@ func (h *HoneycombLogger) Stop() error {
 	return nil
 }
 
-func (h *HoneycombLogger) WithField(key string, value interface{}) Entry {
-	entry := &HoneycombEntry{
-		loggerConfig: h.loggerConfig,
-		builder:      h.builder.Clone(),
-	}
-	entry.builder.AddField(key, value)
-	return entry
-}
-
-func (h *HoneycombLogger) WithFields(fields map[string]interface{}) Entry {
-	entry := &HoneycombEntry{
-		loggerConfig: h.loggerConfig,
-		builder:      h.builder.Clone(),
-	}
-	entry.builder.Add(fields)
-	return entry
-}
-
-func (h *HoneycombLogger) Debugf(f string, args ...interface{}) {
+func (h *HoneycombLogger) Debug() Entry {
 	if h.loggerConfig.level > DebugLevel {
-		return
+		return nullEntry
 	}
-	ev := h.builder.NewEvent()
-	ev.AddField("level", "debug")
-	ev.AddField("msg", fmt.Sprintf(f, args...))
-	ev.Metadata = map[string]string{
-		"api_host": ev.APIHost,
-		"dataset":  ev.Dataset,
+
+	ev := &HoneycombEntry{
+		loggerConfig: h.loggerConfig,
+		builder:      h.builder.Clone(),
 	}
-	ev.Send()
+	ev.builder.AddField("level", "debug")
+
+	return ev
 }
 
-func (h *HoneycombLogger) Infof(f string, args ...interface{}) {
+func (h *HoneycombLogger) Info() Entry {
 	if h.loggerConfig.level > InfoLevel {
-		return
+		return nullEntry
 	}
-	ev := h.builder.NewEvent()
-	ev.AddField("level", "info")
-	ev.AddField("msg", fmt.Sprintf(f, args...))
-	ev.Metadata = map[string]string{
-		"api_host": ev.APIHost,
-		"dataset":  ev.Dataset,
+
+	ev := &HoneycombEntry{
+		loggerConfig: h.loggerConfig,
+		builder:      h.builder.Clone(),
 	}
-	ev.Send()
+	ev.builder.AddField("level", "info")
+
+	return ev
 }
 
-func (h *HoneycombLogger) Errorf(f string, args ...interface{}) {
+func (h *HoneycombLogger) Error() Entry {
 	if h.loggerConfig.level > ErrorLevel {
-		return
+		return nullEntry
 	}
-	ev := h.builder.NewEvent()
-	ev.AddField("level", "error")
-	ev.AddField("msg", fmt.Sprintf(f, args...))
-	ev.Metadata = map[string]string{
-		"api_host": ev.APIHost,
-		"dataset":  ev.Dataset,
+
+	ev := &HoneycombEntry{
+		loggerConfig: h.loggerConfig,
+		builder:      h.builder.Clone(),
 	}
-	ev.Send()
+	ev.builder.AddField("level", "error")
+
+	return ev
 }
 
 func (h *HoneycombLogger) SetLevel(level string) error {
@@ -242,40 +224,8 @@ func (h *HoneycombEntry) WithFields(fields map[string]interface{}) Entry {
 	return h
 }
 
-func (h *HoneycombEntry) Debugf(f string, args ...interface{}) {
-	if h.loggerConfig.level > DebugLevel {
-		return
-	}
+func (h *HoneycombEntry) Logf(f string, args ...interface{}) {
 	ev := h.builder.NewEvent()
-	ev.AddField("level", "debug")
-	ev.AddField("msg", fmt.Sprintf(f, args...))
-	ev.Metadata = map[string]string{
-		"api_host": ev.APIHost,
-		"dataset":  ev.Dataset,
-	}
-	ev.Send()
-}
-
-func (h *HoneycombEntry) Infof(f string, args ...interface{}) {
-	if h.loggerConfig.level > InfoLevel {
-		return
-	}
-	ev := h.builder.NewEvent()
-	ev.AddField("level", "info")
-	ev.AddField("msg", fmt.Sprintf(f, args...))
-	ev.Metadata = map[string]string{
-		"api_host": ev.APIHost,
-		"dataset":  ev.Dataset,
-	}
-	ev.Send()
-}
-
-func (h *HoneycombEntry) Errorf(f string, args ...interface{}) {
-	if h.loggerConfig.level > ErrorLevel {
-		return
-	}
-	ev := h.builder.NewEvent()
-	ev.AddField("level", "error")
 	ev.AddField("msg", fmt.Sprintf(f, args...))
 	ev.Metadata = map[string]string{
 		"api_host": ev.APIHost,

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -16,6 +16,8 @@ type Logger interface {
 }
 
 type Entry interface {
+	// Optimization tip: pass scalar values by reference to avoid spurious heap
+	// allocation when converting them to interface{}.
 	WithField(key string, value interface{}) Entry
 	WithFields(fields map[string]interface{}) Entry
 	Logf(f string, args ...interface{})

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -8,11 +8,9 @@ import (
 )
 
 type Logger interface {
-	WithField(key string, value interface{}) Entry
-	WithFields(fields map[string]interface{}) Entry
-	Debugf(f string, args ...interface{})
-	Infof(f string, args ...interface{})
-	Errorf(f string, args ...interface{})
+	Debug() Entry
+	Info() Entry
+	Error() Entry
 	// SetLevel sets the logging level (debug, info, warn, error)
 	SetLevel(level string) error
 }
@@ -20,9 +18,7 @@ type Logger interface {
 type Entry interface {
 	WithField(key string, value interface{}) Entry
 	WithFields(fields map[string]interface{}) Entry
-	Debugf(f string, args ...interface{})
-	Infof(f string, args ...interface{})
-	Errorf(f string, args ...interface{})
+	Logf(f string, args ...interface{})
 }
 
 func GetLoggerImplementation(c config.Config) Logger {

--- a/logger/logrus.go
+++ b/logger/logrus.go
@@ -27,7 +27,7 @@ func (l *LogrusLogger) Start() error {
 }
 
 func (l *LogrusLogger) Debug() Entry {
-	if l.level > logrus.DebugLevel {
+	if !l.logger.IsLevelEnabled(logrus.DebugLevel) {
 		return nullEntry
 	}
 
@@ -38,7 +38,7 @@ func (l *LogrusLogger) Debug() Entry {
 }
 
 func (l *LogrusLogger) Info() Entry {
-	if l.level > logrus.InfoLevel {
+	if !l.logger.IsLevelEnabled(logrus.InfoLevel) {
 		return nullEntry
 	}
 
@@ -49,7 +49,7 @@ func (l *LogrusLogger) Info() Entry {
 }
 
 func (l *LogrusLogger) Error() Entry {
-	if l.level > logrus.ErrorLevel {
+	if !l.logger.IsLevelEnabled(logrus.ErrorLevel) {
 		return nullEntry
 	}
 
@@ -75,12 +75,14 @@ func (l *LogrusLogger) SetLevel(level string) error {
 func (l *LogrusEntry) WithField(key string, value interface{}) Entry {
 	return &LogrusEntry{
 		entry: l.entry.WithField(key, value),
+		level: l.level,
 	}
 }
 
 func (l *LogrusEntry) WithFields(fields map[string]interface{}) Entry {
 	return &LogrusEntry{
 		entry: l.entry.WithFields(fields),
+		level: l.level,
 	}
 }
 

--- a/logger/mock.go
+++ b/logger/mock.go
@@ -8,47 +8,32 @@ type MockLogger struct {
 
 type MockLoggerEvent struct {
 	l      *MockLogger
+	level  HoneycombLevel
 	Fields map[string]interface{}
 }
 
-func (l *MockLogger) WithField(key string, value interface{}) Entry {
-	e := &MockLoggerEvent{
+func (l *MockLogger) Debug() Entry {
+	return &MockLoggerEvent{
 		l:      l,
+		level:  DebugLevel,
 		Fields: make(map[string]interface{}),
 	}
-	return e.WithField(key, value)
 }
 
-func (l *MockLogger) WithFields(fields map[string]interface{}) Entry {
-	e := &MockLoggerEvent{
+func (l *MockLogger) Info() Entry {
+	return &MockLoggerEvent{
 		l:      l,
+		level:  InfoLevel,
 		Fields: make(map[string]interface{}),
 	}
-	return e.WithFields(fields)
 }
 
-func (l *MockLogger) Debugf(f string, args ...interface{}) {
-	e := &MockLoggerEvent{
+func (l *MockLogger) Error() Entry {
+	return &MockLoggerEvent{
 		l:      l,
+		level:  ErrorLevel,
 		Fields: make(map[string]interface{}),
 	}
-	e.Debugf(f, args...)
-}
-
-func (l *MockLogger) Infof(f string, args ...interface{}) {
-	e := &MockLoggerEvent{
-		l:      l,
-		Fields: make(map[string]interface{}),
-	}
-	e.Infof(f, args...)
-}
-
-func (l *MockLogger) Errorf(f string, args ...interface{}) {
-	e := &MockLoggerEvent{
-		l:      l,
-		Fields: make(map[string]interface{}),
-	}
-	e.Errorf(f, args...)
 }
 
 func (l *MockLogger) SetLevel(level string) error {
@@ -69,17 +54,17 @@ func (e *MockLoggerEvent) WithFields(fields map[string]interface{}) Entry {
 	return e
 }
 
-func (e *MockLoggerEvent) Debugf(f string, args ...interface{}) {
-	e.WithField("debug", fmt.Sprintf(f, args...))
-	e.l.Events = append(e.l.Events, e)
-}
-
-func (e *MockLoggerEvent) Infof(f string, args ...interface{}) {
-	e.WithField("info", fmt.Sprintf(f, args...))
-	e.l.Events = append(e.l.Events, e)
-}
-
-func (e *MockLoggerEvent) Errorf(f string, args ...interface{}) {
-	e.WithField("error", fmt.Sprintf(f, args...))
+func (e *MockLoggerEvent) Logf(f string, args ...interface{}) {
+	msg := fmt.Sprintf(f, args...)
+	switch e.level {
+	case DebugLevel:
+		e.WithField("debug", msg)
+	case InfoLevel:
+		e.WithField("info", msg)
+	case ErrorLevel:
+		e.WithField("error", msg)
+	default:
+		panic("unexpected log level")
+	}
 	e.l.Events = append(e.l.Events, e)
 }

--- a/logger/null.go
+++ b/logger/null.go
@@ -1,18 +1,16 @@
 package logger
 
+var nullEntry = &NullLoggerEntry{}
+
 type NullLogger struct{}
 
-func (n *NullLogger) WithField(key string, value interface{}) Entry  { return &NullLoggerEntry{} }
-func (n *NullLogger) WithFields(fields map[string]interface{}) Entry { return &NullLoggerEntry{} }
-func (n *NullLogger) Debugf(string, ...interface{})                  {}
-func (n *NullLogger) Infof(string, ...interface{})                   {}
-func (n *NullLogger) Errorf(string, ...interface{})                  {}
-func (n *NullLogger) SetLevel(string) error                          { return nil }
+func (n *NullLogger) Debug() Entry          { return nullEntry }
+func (n *NullLogger) Info() Entry           { return nullEntry }
+func (n *NullLogger) Error() Entry          { return nullEntry }
+func (n *NullLogger) SetLevel(string) error { return nil }
 
 type NullLoggerEntry struct{}
 
-func (n *NullLoggerEntry) WithField(key string, value interface{}) Entry  { return &NullLoggerEntry{} }
-func (n *NullLoggerEntry) WithFields(fields map[string]interface{}) Entry { return &NullLoggerEntry{} }
-func (n *NullLoggerEntry) Debugf(string, ...interface{})                  {}
-func (n *NullLoggerEntry) Infof(string, ...interface{})                   {}
-func (n *NullLoggerEntry) Errorf(string, ...interface{})                  {}
+func (n *NullLoggerEntry) WithField(key string, value interface{}) Entry  { return n }
+func (n *NullLoggerEntry) WithFields(fields map[string]interface{}) Entry { return n }
+func (n *NullLoggerEntry) Logf(string, ...interface{})                    {}

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -27,8 +27,8 @@ type PromConfig struct {
 }
 
 func (p *PromMetrics) Start() error {
-	p.Logger.Debugf("Starting PromMetrics")
-	defer func() { p.Logger.Debugf("Finished starting PromMetrics") }()
+	p.Logger.Debug().Logf("Starting PromMetrics")
+	defer func() { p.Logger.Debug().Logf("Finished starting PromMetrics") }()
 	pc := PromConfig{}
 	err := p.Config.GetOtherConfig("PrometheusMetrics", &pc)
 	if err != nil {

--- a/route/errors.go
+++ b/route/errors.go
@@ -52,7 +52,7 @@ func (r *Router) handlerReturnWithError(w http.ResponseWriter, he handlerError, 
 		fields["error.stack_trace"] = string(debug.Stack())
 	}
 
-	r.Logger.WithFields(fields).Errorf("handler returning error")
+	r.Logger.Error().WithFields(fields).Logf("handler returning error")
 
 	w.WriteHeader(he.status)
 

--- a/route/middleware.go
+++ b/route/middleware.go
@@ -99,7 +99,7 @@ func (r *Router) requestLogger(next http.Handler) http.Handler {
 		dur := float64(time.Since(arrivalTime)) / float64(time.Millisecond)
 
 		// log that we did so TODO better formatted http log line
-		r.Logger.Debugf("handled %s request %s %s %s %s %f %d", route.GetName(), reqID, remoteIP, method, url, dur, wrapped.status)
+		r.Logger.Debug().Logf("handled %s request %s %s %s %s %f %d", route.GetName(), reqID, remoteIP, method, url, dur, wrapped.status)
 	})
 }
 

--- a/route/proxy.go
+++ b/route/proxy.go
@@ -13,12 +13,12 @@ import (
 // (eg team api key verification, markers, etc.)
 func (r *Router) proxy(w http.ResponseWriter, req *http.Request) {
 	r.Metrics.IncrementCounter(r.incomingOrPeer + "_router_proxied")
-	r.Logger.Debugf("proxying request for %s", req.URL.Path)
+	r.Logger.Debug().Logf("proxying request for %s", req.URL.Path)
 	upstreamTarget, err := r.Config.GetHoneycombAPI()
 	if err != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		io.WriteString(w, `{"error":"upstream target unavailable"}`)
-		r.Logger.Errorf("error getting honeycomb API config: %s", err)
+		r.Logger.Error().Logf("error getting honeycomb API config: %s", err)
 		return
 	}
 	forwarded := req.Header.Get("X-Forwarded-For")

--- a/sample/deterministic.go
+++ b/sample/deterministic.go
@@ -28,17 +28,17 @@ type DetSamplerConfig struct {
 }
 
 func (d *DeterministicSampler) Start() error {
-	d.Logger.Debugf("Starting DeterministicSampler")
-	defer func() { d.Logger.Debugf("Finished starting DeterministicSampler") }()
+	d.Logger.Debug().Logf("Starting DeterministicSampler")
+	defer func() { d.Logger.Debug().Logf("Finished starting DeterministicSampler") }()
 	if err := d.loadConfigs(); err != nil {
 		return err
 	}
 
 	// listen for config reloads with an errorless version of the reload
 	d.Config.RegisterReloadCallback(func() {
-		d.Logger.Debugf("reloading deterministic sampler config")
+		d.Logger.Debug().Logf("reloading deterministic sampler config")
 		if err := d.loadConfigs(); err != nil {
-			d.Logger.WithField("error", err).Errorf("failed to reload deterministic sampler configs")
+			d.Logger.Error().WithField("error", err).Logf("failed to reload deterministic sampler configs")
 		}
 	})
 
@@ -53,7 +53,7 @@ func (d *DeterministicSampler) loadConfigs() error {
 		return err
 	}
 	if dsConfig.SampleRate < 1 {
-		d.Logger.WithField("sample_rate", dsConfig.SampleRate).Debugf("configured sample rate for deterministic sampler was less than 1; forcing to 1")
+		d.Logger.Debug().WithField("sample_rate", dsConfig.SampleRate).Logf("configured sample rate for deterministic sampler was less than 1; forcing to 1")
 		dsConfig.SampleRate = 1
 	}
 	d.sampleRate = dsConfig.SampleRate

--- a/sample/dynamic_ema.go
+++ b/sample/dynamic_ema.go
@@ -51,8 +51,8 @@ type EMADynSamplerConfig struct {
 }
 
 func (d *EMADynamicSampler) Start() error {
-	d.Logger.Debugf("Starting EMADynamicSampler")
-	defer func() { d.Logger.Debugf("Finished starting EMADynamicSampler") }()
+	d.Logger.Debug().Logf("Starting EMADynamicSampler")
+	defer func() { d.Logger.Debug().Logf("Finished starting EMADynamicSampler") }()
 	dsConfig := EMADynSamplerConfig{}
 	configKey := fmt.Sprintf("SamplerConfig.%s", d.configName)
 	err := d.Config.GetOtherConfig(configKey, &dsConfig)
@@ -60,7 +60,7 @@ func (d *EMADynamicSampler) Start() error {
 		return err
 	}
 	if dsConfig.GoalSampleRate < 1 {
-		d.Logger.Debugf("configured sample rate for dynamic sampler was %d; forcing to 1", dsConfig.GoalSampleRate)
+		d.Logger.Debug().Logf("configured sample rate for dynamic sampler was %d; forcing to 1", dsConfig.GoalSampleRate)
 		dsConfig.GoalSampleRate = 1
 	}
 	d.goalSampleRate = dsConfig.GoalSampleRate
@@ -106,7 +106,7 @@ func (d *EMADynamicSampler) Start() error {
 }
 
 func (d *EMADynamicSampler) reloadConfigs() {
-	d.Logger.Debugf("reloading config for dynamic sampler")
+	d.Logger.Debug().Logf("reloading config for dynamic sampler")
 	// only actually reload the dynsampler if the config changed.
 	var configChanged bool
 
@@ -114,10 +114,10 @@ func (d *EMADynamicSampler) reloadConfigs() {
 	configKey := fmt.Sprintf("SamplerConfig.%s", d.configName)
 	err := d.Config.GetOtherConfig(configKey, &dsConfig)
 	if err != nil {
-		d.Logger.Errorf("Failed to get dynsampler settings when reloading configs:", err)
+		d.Logger.Error().Logf("Failed to get dynsampler settings when reloading configs:", err)
 	}
 	if dsConfig.GoalSampleRate < 1 {
-		d.Logger.Debugf("configured sample rate for dynamic sampler was %d; forcing to 1", dsConfig.GoalSampleRate)
+		d.Logger.Debug().Logf("configured sample rate for dynamic sampler was %d; forcing to 1", dsConfig.GoalSampleRate)
 		dsConfig.GoalSampleRate = 1
 	}
 	if d.goalSampleRate != dsConfig.GoalSampleRate {
@@ -193,11 +193,11 @@ func (d *EMADynamicSampler) reloadConfigs() {
 		}
 		newSampler.Start()
 
-		d.Logger.Debugf("reloaded dynsampler configs with values %+v", dsConfig)
+		d.Logger.Debug().Logf("reloaded dynsampler configs with values %+v", dsConfig)
 
 		d.dynsampler = newSampler
 	} else {
-		d.Logger.Debugf("skipping dynsampler reload because the config of %+v is unchanged from the previous state", dsConfig)
+		d.Logger.Debug().Logf("skipping dynsampler reload because the config of %+v is unchanged from the previous state", dsConfig)
 	}
 }
 
@@ -208,12 +208,12 @@ func (d *EMADynamicSampler) GetSampleRate(trace *types.Trace) (uint, bool) {
 		rate = 1
 	}
 	shouldKeep := rand.Intn(int(rate)) == 0
-	d.Logger.WithFields(map[string]interface{}{
+	d.Logger.Debug().WithFields(map[string]interface{}{
 		"sample_key":  key,
 		"sample_rate": rate,
 		"sample_keep": shouldKeep,
 		"trace_id":    trace.TraceID,
-	}).Debugf("got sample rate and decision")
+	}).Logf("got sample rate and decision")
 	if shouldKeep {
 		d.Metrics.IncrementCounter("dynsampler_num_kept")
 	} else {

--- a/sample/sample.go
+++ b/sample/sample.go
@@ -27,10 +27,10 @@ type SamplerFactory struct {
 func (s *SamplerFactory) GetDefaultSamplerImplementation() Sampler {
 	samplerType, err := s.Config.GetDefaultSamplerType()
 	if err != nil {
-		s.Logger.WithField("error", err).Errorf("unable to get default sampler type from config")
+		s.Logger.Error().WithField("error", err).Logf("unable to get default sampler type from config")
 		os.Exit(1)
 	}
-	s.Logger.Debugf("creating default sampler implementation")
+	s.Logger.Debug().Logf("creating default sampler implementation")
 	return s.getSamplerForType(samplerType, defaultConfigName)
 }
 
@@ -41,7 +41,7 @@ func (s *SamplerFactory) GetSamplerImplementationForDataset(dataset string) Samp
 	if err != nil {
 		return nil
 	}
-	s.Logger.WithField("dataset", dataset).Debugf("creating sampler implementation")
+	s.Logger.Debug().WithField("dataset", dataset).Logf("creating sampler implementation")
 	return s.getSamplerForType(samplerType, dataset)
 }
 
@@ -61,7 +61,7 @@ func (s *SamplerFactory) getSamplerForType(samplerType, configName string) Sampl
 		ds.Start()
 		sampler = ds
 	default:
-		s.Logger.Errorf("unknown sampler type %s. Exiting.", samplerType)
+		s.Logger.Error().Logf("unknown sampler type %s. Exiting.", samplerType)
 		os.Exit(1)
 	}
 

--- a/sharder/deterministic.go
+++ b/sharder/deterministic.go
@@ -85,14 +85,14 @@ type DeterministicSharder struct {
 }
 
 func (d *DeterministicSharder) Start() error {
-	d.Logger.Debugf("Starting DeterministicSharder")
-	defer func() { d.Logger.Debugf("Finished starting DeterministicSharder") }()
+	d.Logger.Debug().Logf("Starting DeterministicSharder")
+	defer func() { d.Logger.Debug().Logf("Finished starting DeterministicSharder") }()
 
 	d.Peers.RegisterUpdatedPeersCallback(func() {
-		d.Logger.Debugf("reloading deterministic sharder config")
+		d.Logger.Debug().Logf("reloading deterministic sharder config")
 		// make an error-less version of the peer reloader
 		if err := d.loadPeerList(); err != nil {
-			d.Logger.Errorf("failed to reload peer list: %+v", err)
+			d.Logger.Error().Logf("failed to reload peer list: %+v", err)
 		}
 	})
 
@@ -114,7 +114,7 @@ func (d *DeterministicSharder) Start() error {
 		if err != nil {
 			return errors.Wrap(err, "failed to parse listen addr into host:port")
 		}
-		d.Logger.Debugf("picked up local peer port of %s", localPort)
+		d.Logger.Debug().Logf("picked up local peer port of %s", localPort)
 
 		// get my local interfaces
 		localAddrs, err := net.InterfaceAddrs()
@@ -126,7 +126,7 @@ func (d *DeterministicSharder) Start() error {
 		// local interface. Note that this assumes only one instance of samproxy per
 		// host can run.
 		for i, peerShard := range d.peers {
-			d.Logger.WithField("peer", peerShard).WithField("self", localAddrs).Debugf("Considering peer looking for self")
+			d.Logger.Debug().WithField("peer", peerShard).WithField("self", localAddrs).Logf("Considering peer looking for self")
 			peerIPList, err := net.LookupHost(peerShard.ipOrHost)
 			if err != nil {
 				// TODO something better than fail to start if peer is missing
@@ -140,7 +140,7 @@ func (d *DeterministicSharder) Start() error {
 					}
 					if peerIP == ipAddr.String() {
 						if peerShard.port == localPort {
-							d.Logger.WithField("peer", peerShard).Debugf("Found myself in peer list")
+							d.Logger.Debug().WithField("peer", peerShard).Logf("Found myself in peer list")
 							found = true
 							selfIndexIntoPeerList = i
 						}
@@ -151,11 +151,11 @@ func (d *DeterministicSharder) Start() error {
 		if found {
 			break
 		}
-		d.Logger.Debugf("Failed to find self in peer list; waiting 5sec and trying again")
+		d.Logger.Debug().Logf("Failed to find self in peer list; waiting 5sec and trying again")
 		time.Sleep(5 * time.Second)
 	}
 	if !found {
-		d.Logger.Debugf("list of current peers: %+v", d.peers)
+		d.Logger.Debug().Logf("list of current peers: %+v", d.peers)
 		return errors.New("failed to find self in the peer list")
 	}
 	d.myShard = d.peers[selfIndexIntoPeerList]
@@ -167,7 +167,7 @@ func (d *DeterministicSharder) Start() error {
 // of peers changes). Because of this, it only updates the in-memory peer list
 // after verifying that it actually changed.
 func (d *DeterministicSharder) loadPeerList() error {
-	d.Logger.Debugf("loading peer list")
+	d.Logger.Debug().Logf("loading peer list")
 	// get my peers
 	peerList, err := d.Peers.GetPeers()
 	if err != nil {
@@ -200,7 +200,7 @@ func (d *DeterministicSharder) loadPeerList() error {
 	// if the peer list changed, load the new list
 	d.peerLock.RLock()
 	if !SortableShardList(d.peers).Equals(newPeers) {
-		d.Logger.Infof("Peer list has changed. New peer list: %+v", newPeers)
+		d.Logger.Info().Logf("Peer list has changed. New peer list: %+v", newPeers)
 		d.peerLock.RUnlock()
 		d.peerLock.Lock()
 		d.peers = newPeers

--- a/sharder/single.go
+++ b/sharder/single.go
@@ -23,6 +23,6 @@ func (s *SingleServerSharder) MyShard() Shard {
 }
 
 func (s *SingleServerSharder) WhichShard(traceID string) Shard {
-	s.Logger.WithField("trace_id", traceID).Debugf("single server sharder; choosing self for trace")
+	s.Logger.Debug().WithField("trace_id", traceID).Logf("single server sharder; choosing self for trace")
 	return &selfShard
 }


### PR DESCRIPTION
Uses a new Logger interface to no-op log operations on disabled log levels. It's a break from the logrus model, but I think it's worth it to avoid unexpected perf issues from a misplaced debug line.