### PR TITLE
add integrated benchmark

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,10 +1,6 @@
 package app
 
 import (
-	"os"
-	"os/signal"
-	"syscall"
-
 	"github.com/honeycombio/samproxy/collect"
 	"github.com/honeycombio/samproxy/config"
 	"github.com/honeycombio/samproxy/logger"
@@ -31,10 +27,6 @@ type App struct {
 func (a *App) Start() error {
 	a.Logger.Debug().Logf("Starting up App...")
 
-	// set up signal channel to exit
-	sigsToExit := make(chan os.Signal, 1)
-	signal.Notify(sigsToExit, syscall.SIGINT, syscall.SIGTERM)
-
 	a.IncomingRouter.SetVersion(a.Version)
 	a.PeerRouter.SetVersion(a.Version)
 
@@ -42,10 +34,6 @@ func (a *App) Start() error {
 	// and external sources
 	go a.IncomingRouter.LnS("incoming")
 	go a.PeerRouter.LnS("peer")
-
-	// block on our signal handler to exit
-	sig := <-sigsToExit
-	a.Logger.Error().Logf("Caught signal \"%s\"", sig)
 
 	return nil
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -81,7 +81,7 @@ func newStartedApp(t testing.TB, libhoneyT transmission.Sender) (*App, inject.Gr
 	c := &config.MockConfig{
 		GetSendDelayVal:          0,
 		GetTraceTimeoutVal:       10 * time.Millisecond,
-		GetDefaultSamplerTypeVal: "DeterministicSampler",
+		GetSamplerTypeVal:        "DeterministicSampler",
 		SendTickerVal:            2 * time.Millisecond,
 		PeerManagementType:       "file",
 		GetOtherConfigVal:        `{"CacheCapacity":10000}`,

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,1 +1,103 @@
 package app
+
+import (
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/facebookgo/inject"
+	"github.com/facebookgo/startstop"
+	"github.com/honeycombio/libhoney-go"
+	"github.com/honeycombio/libhoney-go/transmission"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/honeycombio/samproxy/collect"
+	"github.com/honeycombio/samproxy/config"
+	"github.com/honeycombio/samproxy/internal/peer"
+	"github.com/honeycombio/samproxy/logger"
+	"github.com/honeycombio/samproxy/metrics"
+	"github.com/honeycombio/samproxy/sample"
+	"github.com/honeycombio/samproxy/sharder"
+	"github.com/honeycombio/samproxy/transmit"
+)
+
+func newStartedApp(t *testing.T) (*App, inject.Graph) {
+	c := &config.MockConfig{
+		GetSendDelayVal:          0,
+		GetTraceTimeoutVal:       60 * time.Second,
+		GetDefaultSamplerTypeVal: "DeterministicSampler",
+		SendTickerVal:            2 * time.Millisecond,
+		PeerManagementType:       "file",
+		GetOtherConfigVal:        `{"CacheCapacity":10000}`,
+		GetUpstreamBufferSizeVal: 10000,
+		GetPeerBufferSizeVal:     10000,
+		GetListenAddrVal:         "127.0.0.1:11000",
+		GetPeerListenAddrVal:     "127.0.0.1:11001",
+	}
+
+	peers, err := peer.NewPeers(c)
+	assert.Equal(t, nil, err)
+
+	a := App{}
+
+	lgr := &logger.LogrusLogger{
+		Config: c,
+	}
+	lgr.SetLevel("debug")
+	lgr.Start()
+
+	// TODO use real metrics
+	metricsr := &metrics.MockMetrics{}
+	metricsr.Start()
+
+	collector := &collect.InMemCollector{}
+	shrdr := &sharder.SingleServerSharder{}
+	samplerFactory := &sample.SamplerFactory{}
+
+	upstreamClient, err := libhoney.NewClient(libhoney.ClientConfig{
+		Transmission: &transmission.WriterSender{
+			W: ioutil.Discard,
+		},
+	})
+	assert.Equal(t, nil, err)
+
+	peerClient, err := libhoney.NewClient(libhoney.ClientConfig{
+		Transmission: &transmission.DiscardSender{},
+	})
+	assert.Equal(t, nil, err)
+
+	var g inject.Graph
+	err = g.Provide(
+		&inject.Object{Value: c},
+		&inject.Object{Value: peers},
+		&inject.Object{Value: lgr},
+		&inject.Object{Value: http.DefaultTransport, Name: "upstreamTransport"},
+		&inject.Object{Value: &transmit.DefaultTransmission{LibhClient: upstreamClient, Name: "upstream_"}, Name: "upstreamTransmission"},
+		&inject.Object{Value: &transmit.DefaultTransmission{LibhClient: peerClient, Name: "peer_"}, Name: "peerTransmission"},
+		&inject.Object{Value: shrdr},
+		&inject.Object{Value: collector},
+		&inject.Object{Value: metricsr},
+		&inject.Object{Value: "test", Name: "version"},
+		&inject.Object{Value: samplerFactory},
+		&inject.Object{Value: &a},
+	)
+	assert.Equal(t, nil, err)
+
+	err = g.Populate()
+	assert.Equal(t, nil, err)
+
+	err = startstop.Start(g.Objects(), nil)
+	assert.Equal(t, nil, err)
+
+	// Racy: wait just a moment for ListenAndServe to start up.
+	time.Sleep(10 * time.Millisecond)
+	return &a, g
+}
+
+func TestAppIntegration(t *testing.T) {
+	_, graph := newStartedApp(t)
+
+	err := startstop.Stop(graph.Objects(), nil)
+	assert.Equal(t, nil, err)
+}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,8 +1,11 @@
 package app
 
 import (
-	"io/ioutil"
+	"bytes"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,7 +25,7 @@ import (
 	"github.com/honeycombio/samproxy/transmit"
 )
 
-func newStartedApp(t *testing.T) (*App, inject.Graph) {
+func newStartedApp(t *testing.T, libhoneyOut io.Writer) (*App, inject.Graph) {
 	c := &config.MockConfig{
 		GetSendDelayVal:          0,
 		GetTraceTimeoutVal:       60 * time.Second,
@@ -34,17 +37,18 @@ func newStartedApp(t *testing.T) (*App, inject.Graph) {
 		GetPeerBufferSizeVal:     10000,
 		GetListenAddrVal:         "127.0.0.1:11000",
 		GetPeerListenAddrVal:     "127.0.0.1:11001",
+		GetAPIKeysVal:            []string{"KEY"},
 	}
 
 	peers, err := peer.NewPeers(c)
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 
 	a := App{}
 
 	lgr := &logger.LogrusLogger{
 		Config: c,
 	}
-	lgr.SetLevel("debug")
+	lgr.SetLevel("info")
 	lgr.Start()
 
 	// TODO use real metrics
@@ -57,15 +61,15 @@ func newStartedApp(t *testing.T) (*App, inject.Graph) {
 
 	upstreamClient, err := libhoney.NewClient(libhoney.ClientConfig{
 		Transmission: &transmission.WriterSender{
-			W: ioutil.Discard,
+			W: libhoneyOut,
 		},
 	})
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 
 	peerClient, err := libhoney.NewClient(libhoney.ClientConfig{
 		Transmission: &transmission.DiscardSender{},
 	})
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 
 	var g inject.Graph
 	err = g.Provide(
@@ -82,13 +86,13 @@ func newStartedApp(t *testing.T) (*App, inject.Graph) {
 		&inject.Object{Value: samplerFactory},
 		&inject.Object{Value: &a},
 	)
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 
 	err = g.Populate()
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 
 	err = startstop.Start(g.Objects(), nil)
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
 
 	// Racy: wait just a moment for ListenAndServe to start up.
 	time.Sleep(10 * time.Millisecond)
@@ -96,8 +100,38 @@ func newStartedApp(t *testing.T) (*App, inject.Graph) {
 }
 
 func TestAppIntegration(t *testing.T) {
-	_, graph := newStartedApp(t)
+	var out bytes.Buffer
+	_, graph := newStartedApp(t, &out)
 
-	err := startstop.Stop(graph.Objects(), nil)
-	assert.Equal(t, nil, err)
+	// Send a root span, it should be sent in short order.
+	req := httptest.NewRequest(
+		"POST",
+		"http://localhost:11000/1/batch/dataset",
+		strings.NewReader(`[{"data":{"trace.trace_id":"1","foo":"bar"}}]`),
+	)
+	req.Header.Set("X-Honeycomb-Team", "KEY")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	// Wait for span to be sent.
+	deadline := time.After(time.Second)
+	for {
+		if out.Len() > 62 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Error("timed out waiting for output")
+			return
+		case <-time.After(time.Millisecond):
+		}
+	}
+	assert.Equal(t, `{"data":{"foo":"bar","trace.trace_id":"1"},"dataset":"dataset"}`+"\n", out.String())
+
+	err = startstop.Stop(graph.Objects(), nil)
+	assert.NoError(t, err)
 }

--- a/cmd/samproxy/main.go
+++ b/cmd/samproxy/main.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	libhoney "github.com/honeycombio/libhoney-go"
@@ -198,4 +200,12 @@ func main() {
 		fmt.Printf("failed to start injected dependencies. error: %+v\n", err)
 		os.Exit(1)
 	}
+
+	// set up signal channel to exit
+	sigsToExit := make(chan os.Signal, 1)
+	signal.Notify(sigsToExit, syscall.SIGINT, syscall.SIGTERM)
+
+	// block on our signal handler to exit
+	sig := <-sigsToExit
+	a.Logger.Error().Logf("Caught signal \"%s\"", sig)
 }

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -287,7 +287,6 @@ func (i *InMemCollector) processSpan(sp *types.Span) {
 		i.Metrics.IncrementCounter("trace_accepted")
 
 		timeout, err := i.Config.GetTraceTimeout()
-
 		if err != nil {
 			timeout = 60 * time.Second
 		}

--- a/collect/collect_benchmark_test.go
+++ b/collect/collect_benchmark_test.go
@@ -59,8 +59,8 @@ func BenchmarkCollect(b *testing.B) {
 	assert.NoError(b, err, "lru cache should start")
 	coll.sentTraceCache = stc
 
-	coll.incoming = make(chan *types.Span, 5)
-	coll.fromPeer = make(chan *types.Span, 5)
+	coll.incoming = make(chan *types.Span, 500)
+	coll.fromPeer = make(chan *types.Span, 500)
 	coll.datasetSamplers = make(map[string]sample.Sampler)
 	go coll.collect()
 

--- a/metrics/mock.go
+++ b/metrics/mock.go
@@ -1,5 +1,7 @@
 package metrics
 
+import "sync"
+
 // MockMetrics collects metrics that were registered and changed to allow tests to
 // verify expected behavior
 type MockMetrics struct {
@@ -7,6 +9,8 @@ type MockMetrics struct {
 	CounterIncrements map[string]int
 	GaugeRecords      map[string]float64
 	Histograms        map[string][]float64
+
+	lock sync.Mutex
 }
 
 // Start initializes all metrics or resets all metrics to zero
@@ -18,15 +22,27 @@ func (m *MockMetrics) Start() {
 }
 
 func (m *MockMetrics) Register(name string, metricType string) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
 	m.Registrations[name] = metricType
 }
 func (m *MockMetrics) IncrementCounter(name string) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
 	m.CounterIncrements[name] += 1
 }
 func (m *MockMetrics) Gauge(name string, val float64) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
 	m.GaugeRecords[name] = val
 }
 func (m *MockMetrics) Histogram(name string, obs float64) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
 	_, ok := m.Histograms[name]
 	if !ok {
 		m.Histograms[name] = make([]float64, 0)


### PR DESCRIPTION
This is single-node, but captures a lot of the work involved in sending traces. The code's pretty rough and ready but it gets the job done. This shows many more allocations in today's code vs the pre-ticker code, and even more before my log changes. I think that's the source of circle's regression.

Also moves the signal handler out of App.Start into main, so you can Start an app without blocking.