### PR TITLE
remove traces from cache after they are sent

### DIFF
--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -95,7 +95,7 @@ func (d *DefaultInMemCache) Set(trace *types.Trace) *types.Trace {
 	oldTrace := d.insertionOrder[d.insertPoint]
 	if oldTrace != nil {
 		delete(d.cache, oldTrace.TraceID)
-		if !oldTrace.GetSent() {
+		if !oldTrace.Sent {
 			// if it hasn't already been sent,
 			// record that we're overrunning the buffer
 			d.Metrics.IncrementCounter("collect_cache_buffer_overrun")
@@ -113,11 +113,14 @@ func (d *DefaultInMemCache) Get(traceID string) *types.Trace {
 }
 
 // GetAll is not thread safe and should only be used when that's ok
+// Returns all non-nil trace entries.
 func (d *DefaultInMemCache) GetAll() []*types.Trace {
-	// make a copy so it doesn't get modified for the poor soul trying to use
-	// this list after it's returned
-	tmp := make([]*types.Trace, len(d.insertionOrder))
-	copy(tmp, d.insertionOrder)
+	tmp := make([]*types.Trace, 0, len(d.insertionOrder))
+	for _, t := range d.insertionOrder {
+		if t != nil {
+			tmp = append(tmp, t)
+		}
+	}
 	return tmp
 }
 

--- a/collect/cache/cache_test.go
+++ b/collect/cache/cache_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -52,4 +53,44 @@ func TestBufferOverrun(t *testing.T) {
 	assert.Equal(t, 0, s.CounterIncrements["collect_cache_buffer_overrun"], "buffer should not yet have overrun")
 	c.Set(traces[2])
 	assert.Equal(t, 1, s.CounterIncrements["collect_cache_buffer_overrun"], "buffer should have overrun")
+}
+
+func TestTakeExpiredTraces(t *testing.T) {
+	s := &metrics.MockMetrics{}
+	s.Start()
+	c := &DefaultInMemCache{
+		Config:  CacheConfig{10},
+		Metrics: s,
+		Logger:  &logger.NullLogger{},
+	}
+	c.Start()
+
+	now := time.Now()
+	traces := []*types.Trace{
+		&types.Trace{TraceID: "1", SendBy: now.Add(-time.Minute), Sent: true},
+		&types.Trace{TraceID: "2", SendBy: now.Add(-time.Minute)},
+		&types.Trace{TraceID: "3", SendBy: now.Add(time.Minute)},
+		&types.Trace{TraceID: "4"},
+	}
+	for _, t := range traces {
+		c.Set(t)
+	}
+
+	expired := c.TakeExpiredTraces(now)
+	assert.Equal(t, 3, len(expired))
+	assert.Equal(t, traces[0], expired[0])
+	assert.Equal(t, traces[1], expired[1])
+	assert.Equal(t, traces[3], expired[2])
+
+	assert.Equal(t, 1, len(c.cache))
+
+	all := c.GetAll()
+	assert.Equal(t, 10, len(all))
+	for i := range all {
+		if i == 2 {
+			assert.Equal(t, traces[2], all[i])
+			continue
+		}
+		assert.Nil(t, all[i])
+	}
 }

--- a/collect/cache/cache_test.go
+++ b/collect/cache/cache_test.go
@@ -85,12 +85,8 @@ func TestTakeExpiredTraces(t *testing.T) {
 	assert.Equal(t, 1, len(c.cache))
 
 	all := c.GetAll()
-	assert.Equal(t, 10, len(all))
+	assert.Equal(t, 1, len(all))
 	for i := range all {
-		if i == 2 {
-			assert.Equal(t, traces[2], all[i])
-			continue
-		}
-		assert.Nil(t, all[i])
+		assert.Equal(t, traces[2], all[i])
 	}
 }

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -258,14 +258,9 @@ func (i *InMemCollector) collect() {
 }
 
 func (i *InMemCollector) sendTracesInCache(now time.Time) {
-	traces := i.Cache.GetAll()
-
+	traces := i.Cache.TakeExpiredTraces(now)
 	for _, t := range traces {
-		if t != nil {
-			if now.After(t.SendBy) {
-				i.send(t)
-			}
-		}
+		i.send(t)
 	}
 }
 
@@ -434,9 +429,7 @@ func (i *InMemCollector) Stop() error {
 		traces := i.Cache.GetAll()
 		for _, trace := range traces {
 			if trace != nil {
-				if !trace.GetSent() {
-					i.send(trace)
-				}
+				i.send(trace)
 			}
 		}
 	}

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -68,11 +68,13 @@ func TestAddRootSpan(t *testing.T) {
 		},
 	}
 	coll.AddSpan(span)
+
 	time.Sleep(conf.SendTickerVal * 2)
 	// adding one span with no parent ID should:
 	// * create the trace in the cache
 	// * send the trace
-	assert.Equal(t, traceID1, coll.Cache.Get(traceID1).TraceID, "after adding the span, we should have a trace in the cache with the right trace ID")
+	// * remove the trace from the cache
+	assert.Nil(t, coll.Cache.Get(traceID1), "after sending the span, it should be removed from the cache")
 	transmission.Mux.RLock()
 	assert.Equal(t, 1, len(transmission.Events), "adding a root span should send the span")
 	assert.Equal(t, "aoeu", transmission.Events[0].Dataset, "sending a root span should immediately send that span via transmission")
@@ -89,7 +91,8 @@ func TestAddRootSpan(t *testing.T) {
 	// adding one span with no parent ID should:
 	// * create the trace in the cache
 	// * send the trace
-	assert.Equal(t, traceID2, coll.Cache.Get(traceID2).TraceID, "after adding the span, we should have a trace in the cache with the right trace ID")
+	// * remove the trace from the cache
+	assert.Nil(t, coll.Cache.Get(traceID1), "after sending the span, it should be removed from the cache")
 	transmission.Mux.RLock()
 	assert.Equal(t, 2, len(transmission.Events), "adding another root span should send the span")
 	assert.Equal(t, "aoeu", transmission.Events[1].Dataset, "sending a root span should immediately send that span via transmission")
@@ -161,7 +164,7 @@ func TestAddSpan(t *testing.T) {
 	}
 	coll.AddSpan(rootSpan)
 	time.Sleep(conf.SendTickerVal * 2)
-	assert.Equal(t, 2, len(coll.Cache.Get(traceID).GetSpans()), "after adding a leaf and root span, we should have a two spans in the cache")
+	assert.Nil(t, coll.Cache.Get(traceID), "after adding a leaf and root span, it should be removed from the cache")
 	transmission.Mux.RLock()
 	assert.Equal(t, 2, len(transmission.Events), "adding a root span should send all spans in the trace")
 	transmission.Mux.RUnlock()
@@ -235,7 +238,8 @@ func TestDryRunMode(t *testing.T) {
 	// adding one span with no parent ID should:
 	// * create the trace in the cache
 	// * send the trace
-	assert.Equal(t, traceID1, coll.Cache.Get(traceID1).TraceID, "after adding the span, we should have a trace in the cache with the right trace ID")
+	// * remove the trace from the cache
+	assert.Nil(t, coll.Cache.Get(traceID1), "after sending the span, it should be removed from the cache")
 	transmission.Mux.RLock()
 	assert.Equal(t, 1, len(transmission.Events), "adding a root span should send the span")
 	assert.Equal(t, keepTraceID1, transmission.Events[0].Data["samproxy_kept"], "field should match sampling decision for its trace ID")
@@ -282,7 +286,8 @@ func TestDryRunMode(t *testing.T) {
 	// adding one span with no parent ID should:
 	// * create the trace in the cache
 	// * send the trace
-	assert.Equal(t, traceID3, coll.Cache.Get(traceID3).TraceID, "after adding the span, we should have a trace in the cache with the right trace ID")
+	// * remove the trace from the cache
+	assert.Nil(t, coll.Cache.Get(traceID3), "after sending the span, it should be removed from the cache")
 	transmission.Mux.RLock()
 	assert.Equal(t, 4, len(transmission.Events), "adding a root span should send the span")
 	assert.Equal(t, keepTraceID3, transmission.Events[3].Data["samproxy_kept"], "field should match sampling decision for its trace ID")

--- a/types/event.go
+++ b/types/event.go
@@ -95,12 +95,6 @@ type Trace struct {
 	spans []*Span
 }
 
-// GetSent returns true if this trace has already been sent, false if it has not
-// yet been sent.
-func (t *Trace) GetSent() bool {
-	return t.Sent
-}
-
 // AddSpan adds a span to this trace
 func (t *Trace) AddSpan(sp *Span) {
 	t.spans = append(t.spans, sp)


### PR DESCRIPTION
Moves some of this logic into the cache so it can be done efficiently. This should lower the memory footprint when the cache capacity is set larger than necessary, and should fix the perf regression associated with repeatedly touching already-sent traces in sendTracesInCache().

The improvement is visible using the benchmark in #131 

```
benchmark                    old ns/op     new ns/op     delta
BenchmarkTraces/batch-8      23715         16990         -28.36%

benchmark                    old allocs     new allocs     delta
BenchmarkTraces/batch-8      286            164            -42.66%
```