### PR TITLE
fix broken log line, add WithString for efficiently skipped logs

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -408,9 +408,9 @@ func (i *InMemCollector) send(trace *types.Trace) {
 
 	// ok, we're not dropping this trace; send all the spans
 	if i.Config.GetIsDryRun() && !shouldSend {
-		i.Logger.Info().WithField("trace_id", &trace.TraceID).WithField("dataset", &trace.Dataset).Logf("Trace would have been dropped, but dry run mode is enabled")
+		i.Logger.Info().WithField("trace_id", trace.TraceID).WithField("dataset", trace.Dataset).Logf("Trace would have been dropped, but dry run mode is enabled")
 	}
-	i.Logger.Info().WithField("trace_id", &trace.TraceID).WithField("dataset", &trace.Dataset).Logf("Sending trace to dataset")
+	i.Logger.Info().WithField("trace_id", trace.TraceID).WithField("dataset", trace.Dataset).Logf("Sending trace to dataset")
 	for _, sp := range trace.GetSpans() {
 		if sp.SampleRate < 1 {
 			sp.SampleRate = 1

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -366,8 +366,8 @@ func (i *InMemCollector) send(trace *types.Trace) {
 		// when two timers race and two signals for the same trace are sent down the
 		// toSend channel
 		i.Logger.Debug().
-			WithField("trace_id", trace.TraceID).
-			WithField("dataset", trace.Dataset).
+			WithString("trace_id", trace.TraceID).
+			WithString("dataset", trace.Dataset).
 			Logf("skipping send because someone else already sent trace to dataset")
 		return
 	}
@@ -401,16 +401,16 @@ func (i *InMemCollector) send(trace *types.Trace) {
 	// if we're supposed to drop this trace, and dry run mode is not enabled, then we're done.
 	if !shouldSend && !i.Config.GetIsDryRun() {
 		i.Metrics.IncrementCounter("trace_send_dropped")
-		i.Logger.Info().WithField("trace_id", trace.TraceID).WithField("dataset", trace.Dataset).Logf("Dropping trace because of sampling, trace to dataset")
+		i.Logger.Info().WithString("trace_id", trace.TraceID).WithString("dataset", trace.Dataset).Logf("Dropping trace because of sampling, trace to dataset")
 		return
 	}
 	i.Metrics.IncrementCounter("trace_send_kept")
 
 	// ok, we're not dropping this trace; send all the spans
 	if i.Config.GetIsDryRun() && !shouldSend {
-		i.Logger.Info().WithField("trace_id", trace.TraceID).WithField("dataset", trace.Dataset).Logf("Trace would have been dropped, but dry run mode is enabled")
+		i.Logger.Info().WithString("trace_id", trace.TraceID).WithString("dataset", trace.Dataset).Logf("Trace would have been dropped, but dry run mode is enabled")
 	}
-	i.Logger.Info().WithField("trace_id", trace.TraceID).WithField("dataset", trace.Dataset).Logf("Sending trace to dataset")
+	i.Logger.Info().WithString("trace_id", trace.TraceID).WithString("dataset", trace.Dataset).Logf("Sending trace to dataset")
 	for _, sp := range trace.GetSpans() {
 		if sp.SampleRate < 1 {
 			sp.SampleRate = 1

--- a/logger/honeycomb.go
+++ b/logger/honeycomb.go
@@ -219,6 +219,10 @@ func (h *HoneycombEntry) WithField(key string, value interface{}) Entry {
 	return h
 }
 
+func (h *HoneycombEntry) WithString(key string, value string) Entry {
+	return h.WithField(key, value)
+}
+
 func (h *HoneycombEntry) WithFields(fields map[string]interface{}) Entry {
 	h.builder.Add(fields)
 	return h

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -16,8 +16,6 @@ type Logger interface {
 }
 
 type Entry interface {
-	// Optimization tip: pass scalar values by reference to avoid spurious heap
-	// allocation when converting them to interface{}.
 	WithField(key string, value interface{}) Entry
 	WithFields(fields map[string]interface{}) Entry
 	Logf(f string, args ...interface{})

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -17,6 +17,11 @@ type Logger interface {
 
 type Entry interface {
 	WithField(key string, value interface{}) Entry
+
+	// WithString does the same thing as WithField, but is more efficient for
+	// disabled log levels. (Because the value parameter doesn't escape.)
+	WithString(key string, value string) Entry
+
 	WithFields(fields map[string]interface{}) Entry
 	Logf(f string, args ...interface{})
 }

--- a/logger/logrus.go
+++ b/logger/logrus.go
@@ -79,6 +79,13 @@ func (l *LogrusEntry) WithField(key string, value interface{}) Entry {
 	}
 }
 
+func (l *LogrusEntry) WithString(key string, value string) Entry {
+	return &LogrusEntry{
+		entry: l.entry.WithField(key, value),
+		level: l.level,
+	}
+}
+
 func (l *LogrusEntry) WithFields(fields map[string]interface{}) Entry {
 	return &LogrusEntry{
 		entry: l.entry.WithFields(fields),

--- a/logger/mock.go
+++ b/logger/mock.go
@@ -46,6 +46,10 @@ func (e *MockLoggerEvent) WithField(key string, value interface{}) Entry {
 	return e
 }
 
+func (e *MockLoggerEvent) WithString(key string, value string) Entry {
+	return e.WithField(key, value)
+}
+
 func (e *MockLoggerEvent) WithFields(fields map[string]interface{}) Entry {
 	for k, v := range fields {
 		e.Fields[k] = v

--- a/logger/null.go
+++ b/logger/null.go
@@ -12,5 +12,6 @@ func (n *NullLogger) SetLevel(string) error { return nil }
 type NullLoggerEntry struct{}
 
 func (n *NullLoggerEntry) WithField(key string, value interface{}) Entry  { return n }
+func (n *NullLoggerEntry) WithString(key string, value string) Entry      { return n }
 func (n *NullLoggerEntry) WithFields(fields map[string]interface{}) Entry { return n }
 func (n *NullLoggerEntry) Logf(string, ...interface{})                    {}


### PR DESCRIPTION
Turns out logrus doesn't do what I want when I pass a pointer to a string to WithField. Instead, add WithString() to the Logger interface, which avoids the heap allocation for skipped logs. It's a bit awkward to have both but I think that's a small price to pay for a simple way to avoid vast quantities of garbage.

For background, the problem with `WithField()` is that passing a scalar into the `interface{}` value param causes it to escape to the heap, even if it's ultimately not used. This can add up to a lot of allocations for frequent log lines, and is a huge waste when those logs are disabled. However, a typed `string` value doesn't escape here, so calling `WithString()` is essentially free for disabled log levels.