### PR TITLE
Simplify the way that the sampler rules are described

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -99,7 +99,7 @@ func newStartedApp(
 	c := &config.MockConfig{
 		GetSendDelayVal:                      0,
 		GetTraceTimeoutVal:                   10 * time.Millisecond,
-		GetSamplerTypeVal:                    "DeterministicSampler",
+		GetSamplerTypeVal:                    &config.DeterministicSamplerConfig{},
 		SendTickerVal:                        2 * time.Millisecond,
 		PeerManagementType:                   "file",
 		GetUpstreamBufferSizeVal:             10000,

--- a/collect/collect_benchmark_test.go
+++ b/collect/collect_benchmark_test.go
@@ -24,7 +24,7 @@ func BenchmarkCollect(b *testing.B) {
 	conf := &config.MockConfig{
 		GetSendDelayVal:    0,
 		GetTraceTimeoutVal: 60 * time.Second,
-		GetSamplerTypeVal:  "DeterministicSampler",
+		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{},
 		SendTickerVal:      2 * time.Millisecond,
 	}
 

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -24,7 +24,7 @@ func TestAddRootSpan(t *testing.T) {
 	conf := &config.MockConfig{
 		GetSendDelayVal:    0,
 		GetTraceTimeoutVal: 60 * time.Second,
-		GetSamplerTypeVal:  "DeterministicSampler",
+		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{},
 		SendTickerVal:      2 * time.Millisecond,
 	}
 	coll := &InMemCollector{
@@ -108,7 +108,7 @@ func TestAddSpan(t *testing.T) {
 	conf := &config.MockConfig{
 		GetSendDelayVal:    0,
 		GetTraceTimeoutVal: 60 * time.Second,
-		GetSamplerTypeVal:  "DeterministicSampler",
+		GetSamplerTypeVal:  &config.DeterministicSamplerConfig{},
 		SendTickerVal:      2 * time.Millisecond,
 	}
 	coll := &InMemCollector{
@@ -178,10 +178,11 @@ func TestDryRunMode(t *testing.T) {
 	conf := &config.MockConfig{
 		GetSendDelayVal:    0,
 		GetTraceTimeoutVal: 60 * time.Second,
-		GetSamplerTypeVal:  "DeterministicSampler",
-		SendTickerVal:      2 * time.Millisecond,
-		GetOtherConfigVal:  `{"SampleRate":10}`,
-		DryRun:             true,
+		GetSamplerTypeVal: &config.DeterministicSamplerConfig{
+			SampleRate: 10,
+		},
+		SendTickerVal: 2 * time.Millisecond,
+		DryRun:        true,
 	}
 	samplerFactory := &sample.SamplerFactory{
 		Config: conf,
@@ -303,7 +304,7 @@ func TestSampleConfigReload(t *testing.T) {
 	conf := &config.MockConfig{
 		GetSendDelayVal:                      0,
 		GetTraceTimeoutVal:                   10 * time.Millisecond,
-		GetSamplerTypeVal:                    "DeterministicSampler",
+		GetSamplerTypeVal:                    &config.DeterministicSamplerConfig{},
 		SendTickerVal:                        2 * time.Millisecond,
 		GetInMemoryCollectorCacheCapacityVal: config.InMemoryCollectorCacheCapacity{CacheCapacity: 10},
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -73,8 +73,8 @@ type Config interface {
 	// GetInMemCollectorCacheCapacity returns the config specific to the InMemCollector
 	GetInMemCollectorCacheCapacity() (InMemoryCollectorCacheCapacity, error)
 
-	// GetSamplerTypeForDataset returns the sampler type to use for the given dataset
-	GetSamplerTypeForDataset(string) (string, error)
+	// GetSamplerConfigForDataset returns the sampler type to use for the given dataset
+	GetSamplerConfigForDataset(string) (interface{}, error)
 
 	// GetMetricsType returns the type of metrics to use. Valid types are in the
 	// metrics package

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -99,12 +99,12 @@ func TestReadDefaults(t *testing.T) {
 		t.Error("received", d, "expected", 100*time.Millisecond)
 	}
 
-	if d, _ := c.GetSamplerTypeForDataset("dataset-doesnt-exist"); d != "DeterministicSampler" {
-		t.Error("received", d, "expected", "DeterministicSampler")
+	if d, err := c.GetSamplerConfigForDataset("dataset-doesnt-exist"); err != nil {
+		assert.IsType(t, &DeterministicSamplerConfig{}, d)
 	}
 
-	if d, _ := c.GetSamplerTypeForDataset("dataset1"); d != "DynamicSampler" {
-		t.Error("received", d, "expected", "DynamicSampler")
+	if d, err := c.GetSamplerConfigForDataset("dataset1"); err != nil {
+		assert.IsType(t, &DynamicSamplerConfig{}, d)
 	}
 
 	if d, _ := c.GetPeers(); !(len(d) == 1 && d[0] == "http://127.0.0.1:8081") {
@@ -257,11 +257,10 @@ func TestGetSamplerTypes(t *testing.T) {
 	assert.Equal(t, nil, err)
 
 	dummyConfig := []byte(`
-	[SamplerConfig._default]
-		Sampler = "DeterministicSampler"
-		SampleRate = 2
+	Sampler = "DeterministicSampler"
+	SampleRate = 2
 
-	[SamplerConfig.'dataset 1']
+	['dataset 1']
 		Sampler = "DynamicSampler"
 		SampleRate = 2
 		FieldList = ["request.method","response.status_code"]
@@ -270,12 +269,12 @@ func TestGetSamplerTypes(t *testing.T) {
 		AddSampleRateKeyToTraceField = "meta.samproxy.dynsampler_key"
 		ClearFrequencySec = 60
 
-	[SamplerConfig.dataset2]
+	[dataset2]
 
 		Sampler = "DeterministicSampler"
 		SampleRate = 10
 
-	[SamplerConfig.dataset3]
+	[dataset3]
 
 		Sampler = "EMADynamicSampler"
 		GoalSampleRate = 10
@@ -291,19 +290,19 @@ func TestGetSamplerTypes(t *testing.T) {
 		t.Error(err)
 	}
 
-	typ, err := c.GetSamplerTypeForDataset("dataset-doesnt-exist")
-	assert.Equal(t, nil, err)
-	assert.Equal(t, "DeterministicSampler", typ)
+	if d, err := c.GetSamplerConfigForDataset("dataset-doesnt-exist"); assert.Equal(t, nil, err) {
+		assert.IsType(t, &DeterministicSamplerConfig{}, d)
+	}
 
-	typ, err = c.GetSamplerTypeForDataset("dataset 1")
-	assert.Equal(t, nil, err)
-	assert.Equal(t, "DynamicSampler", typ)
+	if d, err := c.GetSamplerConfigForDataset("dataset 1"); assert.Equal(t, nil, err) {
+		assert.IsType(t, &DynamicSamplerConfig{}, d)
+	}
 
-	typ, err = c.GetSamplerTypeForDataset("dataset2")
-	assert.Equal(t, nil, err)
-	assert.Equal(t, "DeterministicSampler", typ)
+	if d, err := c.GetSamplerConfigForDataset("dataset2"); assert.Equal(t, nil, err) {
+		assert.IsType(t, &DeterministicSamplerConfig{}, d)
+	}
 
-	typ, err = c.GetSamplerTypeForDataset("dataset3")
-	assert.Equal(t, nil, err)
-	assert.Equal(t, "EMADynamicSampler", typ)
+	if d, err := c.GetSamplerConfigForDataset("dataset3"); assert.Equal(t, nil, err) {
+		assert.IsType(t, &EMADynamicSamplerConfig{}, d)
+	}
 }

--- a/config/mock.go
+++ b/config/mock.go
@@ -35,7 +35,7 @@ type MockConfig struct {
 	GetRedisHostErr               error
 	GetRedisHostVal               string
 	GetSamplerTypeErr             error
-	GetSamplerTypeVal             string
+	GetSamplerTypeVal             interface{}
 	GetMetricsTypeErr             error
 	GetMetricsTypeVal             string
 	GetHoneycombMetricsConfigErr  error
@@ -112,7 +112,7 @@ func (m *MockConfig) GetTraceTimeout() (time.Duration, error) {
 }
 
 // TODO: allow per-dataset mock values
-func (m *MockConfig) GetSamplerTypeForDataset(dataset string) (string, error) {
+func (m *MockConfig) GetSamplerConfigForDataset(dataset string) (interface{}, error) {
 	return m.GetSamplerTypeVal, m.GetSamplerTypeErr
 }
 

--- a/config/sampler_config.go
+++ b/config/sampler_config.go
@@ -1,0 +1,29 @@
+package config
+
+type DeterministicSamplerConfig struct {
+	SampleRate int
+}
+
+type DynamicSamplerConfig struct {
+	SampleRate                   int64
+	ClearFrequencySec            int64
+	FieldList                    []string
+	UseTraceLength               bool
+	AddSampleRateKeyToTrace      bool
+	AddSampleRateKeyToTraceField string
+}
+
+type EMADynamicSamplerConfig struct {
+	GoalSampleRate      int
+	AdjustmentInterval  int
+	Weight              float64
+	AgeOutValue         float64
+	BurstMultiple       float64
+	BurstDetectionDelay uint
+	MaxKeys             int
+
+	FieldList                    []string
+	UseTraceLength               bool
+	AddSampleRateKeyToTrace      bool
+	AddSampleRateKeyToTraceField string
+}

--- a/rules.toml
+++ b/rules.toml
@@ -6,207 +6,196 @@
 # and sends all traces regardless
 # DryRun = false
 
-# Sampler describes which sampling algorithm to use to sample traces. Valid
-# choices are "DeterministicSampler" and "DynamicSampler". The deterministic
-# sampler is a random sampler - each trace has equal chance of being sampled
-# (and that probability is set by the sample rate). The dynamic sampler requires
-# a list of fields to use from the trace and will choose a sample rate based on
-# the frequency of the values contained in those fields. Changing sampling algorithms 
-# requires a process restart; this change will not be picked up by a live config reload. 
-Sampler = "DynamicSampler"
+# DeterministicSampler is a section of the config for manipulating the
+# Deterministic Sampler implementation. This is the simplest sampling algorithm
+# - it is a static sample rate, choosing traces randomly to either keep or send
+# (at the appropriate rate). It is not influenced by the contents of the trace.
+Sampler = "DeterministicSampler"
 
-	[SamplerConfig._default]
+# SampleRate is the rate at which to sample. It indicates a ratio, where one
+# sample trace is kept for every n traces seen. For example, a SampleRate of 30
+# will keep 1 out of every 30 traces. The choice on whether to keep any specific
+# trace is random, so the rate is approximate.
+# Eligible for live reload.
+SampleRate = 1
 
-		# DeterministicSampler is a section of the config for manipulating the
-		# Deterministic Sampler implementation. This is the simplest sampling algorithm
-		# - it is a static sample rate, choosing traces randomly to either keep or send
-		# (at the appropriate rate). It is not influenced by the contents of the trace.
-		Sampler = "DeterministicSampler"
+[dataset1]
 
-		# SampleRate is the rate at which to sample. It indicates a ratio, where one
-		# sample trace is kept for every n traces seen. For example, a SampleRate of 30
-		# will keep 1 out of every 30 traces. The choice on whether to keep any specific
-		# trace is random, so the rate is approximate.
-		# Eligible for live reload.
-		SampleRate = 1
+	# Note: If your dataset name contains a space, you will have to escape the dataset name
+	# using single quotes, such as ['dataset 1']
 
-	[SamplerConfig.dataset1]
+	# DynamicSampler is a section of the config for manipulating the simple Dynamic Sampler
+	# implementation. This sampler collects the values of a number of fields from a
+	# trace and uses them to form a key. This key is handed to the standard dynamic
+	# sampler algorithm which generates a sample rate based on the frequency with
+	# which that key has appeared in the previous ClearFrequencySec seconds. See
+	# https://github.com/honeycombio/dynsampler-go for more detail on the mechanics
+	# of the dynamic sampler.  This sampler uses the AvgSampleRate algorithm from
+	# that package.
+	Sampler = "DynamicSampler"
 
-		# Note: If your dataset name contains a space, you will have to escape the dataset name
-		# using single quotes, such as [SamplerConfig.'dataset 1']
+	# SampleRate is the goal rate at which to sample. It indicates a ratio, where
+	# one sample trace is kept for every n traces seen. For example, a SampleRate of
+	# 30 will keep 1 out of every 30 traces. This rate is handed to the dynamic
+	# sampler, who assigns a sample rate for each trace based on the fields selected
+	# from that trace.
+	# Eligible for live reload.
+	SampleRate = 2
 
-		# DynamicSampler is a section of the config for manipulating the simple Dynamic Sampler
-		# implementation. This sampler collects the values of a number of fields from a
-		# trace and uses them to form a key. This key is handed to the standard dynamic
-		# sampler algorithm which generates a sample rate based on the frequency with
-		# which that key has appeared in the previous ClearFrequencySec seconds. See
-		# https://github.com/honeycombio/dynsampler-go for more detail on the mechanics
-		# of the dynamic sampler.  This sampler uses the AvgSampleRate algorithm from
-		# that package.
-		Sampler = "DynamicSampler"
+	# FieldList is a list of all the field names to use to form the key that will be
+	# handed to the dynamic sampler. The cardinality of the combination of values
+	# from all of these keys should be reasonable in the face of the frequency of
+	# those keys. If the combination of fields in these keys essentially makes them
+	# unique, the dynamic sampler will do no sampling.  If the keys have too few
+	# values, you won't get samples of the most interesting traces. A good key
+	# selection will have consistent values for high frequency boring traffic and
+	# unique values for outliers and interesting traffic. Including an error field
+	# (or something like HTTP status code) is an excellent choice. As an example,
+	# assuming 30 or so endpoints, a combination of HTTP endpoint and status code
+	# would be a good set of keys in order to let you see accurately use of all
+	# endpoints and call out when there is failing traffic to any endpoint. Field
+	# names may come from any span in the trace.
+	# Eligible for live reload.
+	FieldList = ["request.method","response.status_code"]
 
-		# SampleRate is the goal rate at which to sample. It indicates a ratio, where
-		# one sample trace is kept for every n traces seen. For example, a SampleRate of
-		# 30 will keep 1 out of every 30 traces. This rate is handed to the dynamic
-		# sampler, who assigns a sample rate for each trace based on the fields selected
-		# from that trace.
-		# Eligible for live reload.
-		SampleRate = 2
+	# UseTraceLength will add the number of spans in the trace in to the dynamic
+	# sampler as part of the key. The number of spans is exact, so if there are
+	# normally small variations in trace length you may want to leave this off. If
+	# traces are consistent lengths and changes in trace length is a useful
+	# indicator of traces you'd like to see in Honeycomb, set this to true.
+	# Eligible for live reload.
+	UseTraceLength = true
 
-		# FieldList is a list of all the field names to use to form the key that will be
-		# handed to the dynamic sampler. The cardinality of the combination of values
-		# from all of these keys should be reasonable in the face of the frequency of
-		# those keys. If the combination of fields in these keys essentially makes them
-		# unique, the dynamic sampler will do no sampling.  If the keys have too few
-		# values, you won't get samples of the most interesting traces. A good key
-		# selection will have consistent values for high frequency boring traffic and
-		# unique values for outliers and interesting traffic. Including an error field
-		# (or something like HTTP status code) is an excellent choice. As an example,
-		# assuming 30 or so endpoints, a combination of HTTP endpoint and status code
-		# would be a good set of keys in order to let you see accurately use of all
-		# endpoints and call out when there is failing traffic to any endpoint. Field
-		# names may come from any span in the trace.
-		# Eligible for live reload.
-		FieldList = ["request.method","response.status_code"]
+	# AddSampleRateKeyToTrace when this is set to true, the sampler will add a field
+	# to the root span of the trace containing the key used by the sampler to decide
+	# the sample rate. This can be helpful in understanding why the sampler is
+	# making certain decisions about sample rate and help you understand how to
+	# better choose the sample rate key (aka the FieldList setting above) to use.
+	AddSampleRateKeyToTrace = true
 
-		# UseTraceLength will add the number of spans in the trace in to the dynamic
-		# sampler as part of the key. The number of spans is exact, so if there are
-		# normally small variations in trace length you may want to leave this off. If
-		# traces are consistent lengths and changes in trace length is a useful
-		# indicator of traces you'd like to see in Honeycomb, set this to true.
-		# Eligible for live reload.
-		UseTraceLength = true
+	# AddSampleRateKeyToTraceField is the name of the field the sampler will use
+	# when adding the sample rate key to the trace. This setting is only used when
+	# AddSampleRateKeyToTrace is true.
+	AddSampleRateKeyToTraceField = "meta.samproxy.dynsampler_key"
 
-		# AddSampleRateKeyToTrace when this is set to true, the sampler will add a field
-		# to the root span of the trace containing the key used by the sampler to decide
-		# the sample rate. This can be helpful in understanding why the sampler is
-		# making certain decisions about sample rate and help you understand how to
-		# better choose the sample rate key (aka the FieldList setting above) to use.
-		AddSampleRateKeyToTrace = true
+			# ClearFrequencySec is the name of the field the sampler will use to determine
+			# the period over which it will calculate the sample rate. This setting defaults
+			# to 30.
+			# Eligible for live reload.
+	ClearFrequencySec = 60
 
-		# AddSampleRateKeyToTraceField is the name of the field the sampler will use
-		# when adding the sample rate key to the trace. This setting is only used when
-		# AddSampleRateKeyToTrace is true.
-		AddSampleRateKeyToTraceField = "meta.samproxy.dynsampler_key"
+[dataset2]
 
-        # ClearFrequencySec is the name of the field the sampler will use to determine
-        # the period over which it will calculate the sample rate. This setting defaults
-        # to 30.
-        # Eligible for live reload.
-		ClearFrequencySec = 60
+	# EMADynamicSampler is a section of the config for manipulating the Exponential
+	# Moving Average (EMA) Dynamic Sampler implementation. Like the simple DynamicSampler,
+	# it attempts to average a given sample rate, weighting rare traffic and frequent
+	# traffic differently so as to end up with the correct average.
+	#
+	# EMADynamicSampler is an improvement upon the simple DynamicSampler and is recommended
+	# for most use cases. Based on the DynamicSampler implementation, EMADynamicSampler differs
+	# in that rather than compute rate based on a periodic sample of traffic, it maintains an Exponential
+	# Moving Average of counts seen per key, and adjusts this average at regular intervals.
+	# The weight applied to more recent intervals is defined by `weight`, a number between
+	# (0, 1) - larger values weight the average more toward recent observations. In other words,
+	# a larger weight will cause sample rates more quickly adapt to traffic patterns,
+	# while a smaller weight will result in sample rates that are less sensitive to bursts or drops
+	# in traffic and thus more consistent over time.
+	#
+	# Keys that are not found in the EMA will always have a sample
+	# rate of 1. Keys that occur more frequently will be sampled on a logarithmic
+	# curve. In other words, every key will be represented at least once in any
+	# given window and more frequent keys will have their sample rate
+	# increased proportionally to wind up with the goal sample rate.
+	Sampler = "EMADynamicSampler"
 
-	[SamplerConfig.dataset2]
+	# GoalSampleRate is the goal rate at which to sample. It indicates a ratio, where
+	# one sample trace is kept for every n traces seen. For example, a SampleRate of
+	# 30 will keep 1 out of every 30 traces. This rate is handed to the dynamic
+	# sampler, who assigns a sample rate for each trace based on the fields selected
+	# from that trace.
+	# Eligible for live reload.
+	GoalSampleRate = 2
 
-		# EMADynamicSampler is a section of the config for manipulating the Exponential
-		# Moving Average (EMA) Dynamic Sampler implementation. Like the simple DynamicSampler,
-		# it attempts to average a given sample rate, weighting rare traffic and frequent
-		# traffic differently so as to end up with the correct average.
-		#
-		# EMADynamicSampler is an improvement upon the simple DynamicSampler and is recommended
-		# for most use cases. Based on the DynamicSampler implementation, EMADynamicSampler differs
-		# in that rather than compute rate based on a periodic sample of traffic, it maintains an Exponential
-		# Moving Average of counts seen per key, and adjusts this average at regular intervals.
-		# The weight applied to more recent intervals is defined by `weight`, a number between
-		# (0, 1) - larger values weight the average more toward recent observations. In other words,
-		# a larger weight will cause sample rates more quickly adapt to traffic patterns,
-		# while a smaller weight will result in sample rates that are less sensitive to bursts or drops
-		# in traffic and thus more consistent over time.
-		#
-		# Keys that are not found in the EMA will always have a sample
-		# rate of 1. Keys that occur more frequently will be sampled on a logarithmic
-		# curve. In other words, every key will be represented at least once in any
-		# given window and more frequent keys will have their sample rate
-		# increased proportionally to wind up with the goal sample rate.
-		Sampler = "EMADynamicSampler"
+	# FieldList is a list of all the field names to use to form the key that will be
+	# handed to the dynamic sampler. The cardinality of the combination of values
+	# from all of these keys should be reasonable in the face of the frequency of
+	# those keys. If the combination of fields in these keys essentially makes them
+	# unique, the dynamic sampler will do no sampling.  If the keys have too few
+	# values, you won't get samples of the most interesting traces. A good key
+	# selection will have consistent values for high frequency boring traffic and
+	# unique values for outliers and interesting traffic. Including an error field
+	# (or something like HTTP status code) is an excellent choice. As an example,
+	# assuming 30 or so endpoints, a combination of HTTP endpoint and status code
+	# would be a good set of keys in order to let you see accurately use of all
+	# endpoints and call out when there is failing traffic to any endpoint. Field
+	# names may come from any span in the trace.
+	# Eligible for live reload.
+	FieldList = ["request.method","response.status_code"]
 
-		# GoalSampleRate is the goal rate at which to sample. It indicates a ratio, where
-		# one sample trace is kept for every n traces seen. For example, a SampleRate of
-		# 30 will keep 1 out of every 30 traces. This rate is handed to the dynamic
-		# sampler, who assigns a sample rate for each trace based on the fields selected
-		# from that trace.
-		# Eligible for live reload.
-		GoalSampleRate = 2
+	# UseTraceLength will add the number of spans in the trace in to the dynamic
+	# sampler as part of the key. The number of spans is exact, so if there are
+	# normally small variations in trace length you may want to leave this off. If
+	# traces are consistent lengths and changes in trace length is a useful
+	# indicator of traces you'd like to see in Honeycomb, set this to true.
+	# Eligible for live reload.
+	UseTraceLength = true
 
-		# FieldList is a list of all the field names to use to form the key that will be
-		# handed to the dynamic sampler. The cardinality of the combination of values
-		# from all of these keys should be reasonable in the face of the frequency of
-		# those keys. If the combination of fields in these keys essentially makes them
-		# unique, the dynamic sampler will do no sampling.  If the keys have too few
-		# values, you won't get samples of the most interesting traces. A good key
-		# selection will have consistent values for high frequency boring traffic and
-		# unique values for outliers and interesting traffic. Including an error field
-		# (or something like HTTP status code) is an excellent choice. As an example,
-		# assuming 30 or so endpoints, a combination of HTTP endpoint and status code
-		# would be a good set of keys in order to let you see accurately use of all
-		# endpoints and call out when there is failing traffic to any endpoint. Field
-		# names may come from any span in the trace.
-		# Eligible for live reload.
-		FieldList = ["request.method","response.status_code"]
+	# AddSampleRateKeyToTrace when this is set to true, the sampler will add a field
+	# to the root span of the trace containing the key used by the sampler to decide
+	# the sample rate. This can be helpful in understanding why the sampler is
+	# making certain decisions about sample rate and help you understand how to
+	# better choose the sample rate key (aka the FieldList setting above) to use.
+	AddSampleRateKeyToTrace = true
 
-		# UseTraceLength will add the number of spans in the trace in to the dynamic
-		# sampler as part of the key. The number of spans is exact, so if there are
-		# normally small variations in trace length you may want to leave this off. If
-		# traces are consistent lengths and changes in trace length is a useful
-		# indicator of traces you'd like to see in Honeycomb, set this to true.
-		# Eligible for live reload.
-		UseTraceLength = true
+	# AddSampleRateKeyToTraceField is the name of the field the sampler will use
+	# when adding the sample rate key to the trace. This setting is only used when
+	# AddSampleRateKeyToTrace is true.
+	AddSampleRateKeyToTraceField = "meta.samproxy.dynsampler_key"
 
-		# AddSampleRateKeyToTrace when this is set to true, the sampler will add a field
-		# to the root span of the trace containing the key used by the sampler to decide
-		# the sample rate. This can be helpful in understanding why the sampler is
-		# making certain decisions about sample rate and help you understand how to
-		# better choose the sample rate key (aka the FieldList setting above) to use.
-		AddSampleRateKeyToTrace = true
+	# AdjustmentInterval defines how often (in seconds) we adjust the moving average from
+	# recent observations. Default 15s
+	# Eligible for live reload.
+	AdjustmentInterval = 15
 
-		# AddSampleRateKeyToTraceField is the name of the field the sampler will use
-		# when adding the sample rate key to the trace. This setting is only used when
-		# AddSampleRateKeyToTrace is true.
-		AddSampleRateKeyToTraceField = "meta.samproxy.dynsampler_key"
+	# Weight is a value between (0, 1) indicating the weighting factor used to adjust
+	# the EMA. With larger values, newer data will influence the average more, and older
+	# values will be factored out more quickly.  In mathematical literature concerning EMA,
+	# this is referred to as the `alpha` constant.
+	# Default is 0.5
+	# Eligible for live reload.
+	Weight = 0.5
 
-		# AdjustmentInterval defines how often (in seconds) we adjust the moving average from
-		# recent observations. Default 15s
-		# Eligible for live reload.
-		AdjustmentInterval = 15
+	# MaxKeys, if greater than 0, limits the number of distinct keys tracked in EMA.
+	# Once MaxKeys is reached, new keys will not be included in the sample rate map, but
+	# existing keys will continue to be be counted. You can use this to keep the sample rate
+	# map size under control.
+	# Eligible for live reload
+	MaxKeys = 0
 
-		# Weight is a value between (0, 1) indicating the weighting factor used to adjust
-		# the EMA. With larger values, newer data will influence the average more, and older
-		# values will be factored out more quickly.  In mathematical literature concerning EMA,
-		# this is referred to as the `alpha` constant.
-		# Default is 0.5
-		# Eligible for live reload.
-		Weight = 0.5
+	# AgeOutValue indicates the threshold for removing keys from the EMA. The EMA of any key
+	# will approach 0 if it is not repeatedly observed, but will never truly reach it, so we have to
+	# decide what constitutes "zero". Keys with averages below this threshold will be removed
+	# from the EMA. Default is the same as Weight, as this prevents a key with the smallest
+	# integer value (1) from being aged out immediately. This value should generally be <= Weight,
+	# unless you have very specific reasons to set it higher.
+	# Eligible for live reload
+	AgeOutValue = 0.5
 
-		# MaxKeys, if greater than 0, limits the number of distinct keys tracked in EMA.
-		# Once MaxKeys is reached, new keys will not be included in the sample rate map, but
-		# existing keys will continue to be be counted. You can use this to keep the sample rate
-		# map size under control.
-		# Eligible for live reload
-		MaxKeys = 0
+	# BurstMultiple, if set, is multiplied by the sum of the running average of counts to define
+	# the burst detection threshold. If total counts observed for a given interval exceed the threshold
+	# EMA is updated immediately, rather than waiting on the AdjustmentInterval.
+	# Defaults to 2; negative value disables. With a default of 2, if your traffic suddenly doubles,
+	# burst detection will kick in.
+	# Eligible for live reload
+	BurstMultiple = 2.0
 
-		# AgeOutValue indicates the threshold for removing keys from the EMA. The EMA of any key
-		# will approach 0 if it is not repeatedly observed, but will never truly reach it, so we have to
-		# decide what constitutes "zero". Keys with averages below this threshold will be removed
-		# from the EMA. Default is the same as Weight, as this prevents a key with the smallest
-		# integer value (1) from being aged out immediately. This value should generally be <= Weight,
-		# unless you have very specific reasons to set it higher.
-		# Eligible for live reload
-		AgeOutValue = 0.5
+	# BurstDetectionDelay indicates the number of intervals to run after Start is called before
+	# burst detection kicks in.
+	# Defaults to 3
+	# Eligible for live reload
+	BurstDetectionDelay = 3
 
-		# BurstMultiple, if set, is multiplied by the sum of the running average of counts to define
-		# the burst detection threshold. If total counts observed for a given interval exceed the threshold
-		# EMA is updated immediately, rather than waiting on the AdjustmentInterval.
-		# Defaults to 2; negative value disables. With a default of 2, if your traffic suddenly doubles,
-		# burst detection will kick in.
-		# Eligible for live reload
-		BurstMultiple = 2.0
+[dataset3]
 
-		# BurstDetectionDelay indicates the number of intervals to run after Start is called before
-		# burst detection kicks in.
-		# Defaults to 3
-		# Eligible for live reload
-		BurstDetectionDelay = 3
-
-	[SamplerConfig.dataset3]
-
-		Sampler = "DeterministicSampler"
-		SampleRate = 10
+	Sampler = "DeterministicSampler"
+	SampleRate = 10

--- a/sample/deterministic_test.go
+++ b/sample/deterministic_test.go
@@ -1,9 +1,7 @@
 package sample
 
 import (
-	"io/ioutil"
 	"math"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,11 +13,10 @@ import (
 
 // TestInitialization tests that sample rates are consistently returned
 func TestInitialization(t *testing.T) {
-	mc := &config.MockConfig{
-		GetOtherConfigVal: `{"SampleRate":10}`,
-	}
 	ds := &DeterministicSampler{
-		Config: mc,
+		Config: &config.DeterministicSamplerConfig{
+			SampleRate: 10,
+		},
 		Logger: &logger.NullLogger{},
 	}
 
@@ -30,79 +27,12 @@ func TestInitialization(t *testing.T) {
 	assert.Equal(t, uint32(math.MaxUint32/10), ds.upperBound, "upper bound should be correctly calculated")
 }
 
-func TestInitializationFromConfigFile(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
-	assert.Equal(t, nil, err)
-	defer os.RemoveAll(tmpDir)
-
-	f, err := ioutil.TempFile(tmpDir, "*.toml")
-	assert.Equal(t, nil, err)
-
-	dummyConfig := []byte(`
-		[InMemCollector]
-			CacheCapacity=1000 
-
-		[HoneycombMetrics]
-			MetricsHoneycombAPI="http://honeycomb.io"
-			MetricsAPIKey="1234"
-			MetricsDataset="testDatasetName"
-			MetricsReportingInterval=3
-			
-		[SamplerConfig._default]
-			Sampler = "DeterministicSampler"
-			SampleRate = 2
-
-		[SamplerConfig.dataset1]
-			Sampler = "DynamicSampler"
-			SampleRate = 2
-			FieldList = ["request.method","response.status_code"]
-			UseTraceLength = true
-			AddSampleRateKeyToTrace = true
-			AddSampleRateKeyToTraceField = "meta.samproxy.dynsampler_key"
-
-		[SamplerConfig.dataset2]
-
-			Sampler = "DeterministicSampler"
-			SampleRate = 10
-	`)
-
-	_, err = f.Write(dummyConfig)
-	assert.Equal(t, nil, err)
-	f.Close()
-
-	c, err := config.NewConfig(f.Name(), f.Name())
-
-	if err != nil {
-		t.Error(err)
-	}
-
-	ds := &DeterministicSampler{
-		Config:     c,
-		Logger:     &logger.NullLogger{},
-		configName: "_default",
-	}
-	ds.Start()
-
-	assert.Equal(t, 2, ds.sampleRate)
-
-	ds = &DeterministicSampler{
-		Config:     c,
-		Logger:     &logger.NullLogger{},
-		configName: "dataset2",
-	}
-	ds.Start()
-	// ensure we get the dataset value from "SamplerConfig.dataset2"
-	assert.Equal(t, 10, ds.sampleRate)
-
-}
-
 // TestGetSampleRate verifies the same trace ID gets the same response
 func TestGetSampleRate(t *testing.T) {
-	mc := &config.MockConfig{
-		GetOtherConfigVal: `{"SampleRate":10}`,
-	}
 	ds := &DeterministicSampler{
-		Config: mc,
+		Config: &config.DeterministicSamplerConfig{
+			SampleRate: 10,
+		},
 		Logger: &logger.NullLogger{},
 	}
 

--- a/sample/dynamic_ema_test.go
+++ b/sample/dynamic_ema_test.go
@@ -17,15 +17,12 @@ func TestDynamicEMAAddSampleRateKeyToTrace(t *testing.T) {
 	metrics := metrics.MockMetrics{}
 	metrics.Start()
 
-	config := &config.MockConfig{
-		GetOtherConfigVal: `{
-  "FieldList":["http.status_code"],
-  "AddSampleRateKeyToTrace":true,
-  "AddSampleRateKeyToTraceField":"meta.key"
-}`,
-	}
 	sampler := &EMADynamicSampler{
-		Config:  config,
+		Config: &config.EMADynamicSamplerConfig{
+			FieldList:                    []string{"http.status_code"},
+			AddSampleRateKeyToTrace:      true,
+			AddSampleRateKeyToTraceField: "meta.key",
+		},
 		Logger:  &logger.NullLogger{},
 		Metrics: &metrics,
 	}

--- a/sample/dynamic_test.go
+++ b/sample/dynamic_test.go
@@ -17,15 +17,12 @@ func TestDynamicAddSampleRateKeyToTrace(t *testing.T) {
 	metrics := metrics.MockMetrics{}
 	metrics.Start()
 
-	config := &config.MockConfig{
-		GetOtherConfigVal: `{
-  "FieldList":["http.status_code"],
-  "AddSampleRateKeyToTrace":true,
-  "AddSampleRateKeyToTraceField":"meta.key"
-}`,
-	}
 	sampler := &DynamicSampler{
-		Config:  config,
+		Config: &config.DynamicSamplerConfig{
+			FieldList:                    []string{"http.status_code"},
+			AddSampleRateKeyToTrace:      true,
+			AddSampleRateKeyToTraceField: "meta.key",
+		},
 		Logger:  &logger.NullLogger{},
 		Metrics: &metrics,
 	}


### PR DESCRIPTION
Change so that the default is listed above the specific dataset rules and remove the `_default` setting.

Remove SamplerConfig from each of the dataset names.

Means we don't have to test config parsing in any test that involves samplers