### PR TITLE
use more efficient wire serialization

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -162,6 +162,7 @@ func newStartedApp(
 			},
 			BlockOnSend:            true,
 			DisableGzipCompression: true,
+			EnableMsgpackEncoding:  true,
 			Metrics:                sdPeer,
 		},
 	})

--- a/cmd/samproxy/main.go
+++ b/cmd/samproxy/main.go
@@ -119,14 +119,15 @@ func main() {
 	userAgentAddition := "samproxy/" + version
 	upstreamClient, err := libhoney.NewClient(libhoney.ClientConfig{
 		Transmission: &transmission.Honeycomb{
-			MaxBatchSize:         500,
-			BatchTimeout:         libhoney.DefaultBatchTimeout,
-			MaxConcurrentBatches: libhoney.DefaultMaxConcurrentBatches,
-			PendingWorkCapacity:  uint(c.GetUpstreamBufferSize()),
-			UserAgentAddition:    userAgentAddition,
-			Transport:            upstreamTransport,
-			BlockOnSend:          true,
-			Metrics:              sdUpstream,
+			MaxBatchSize:          500,
+			BatchTimeout:          libhoney.DefaultBatchTimeout,
+			MaxConcurrentBatches:  libhoney.DefaultMaxConcurrentBatches,
+			PendingWorkCapacity:   uint(c.GetUpstreamBufferSize()),
+			UserAgentAddition:     userAgentAddition,
+			Transport:             upstreamTransport,
+			BlockOnSend:           true,
+			EnableMsgpackEncoding: true,
+			Metrics:               sdUpstream,
 		},
 	})
 	if err != nil {
@@ -146,6 +147,7 @@ func main() {
 			// gzip compression is expensive, and peers are most likely close to each other
 			// so we can turn off gzip when forwarding to peers
 			DisableGzipCompression: true,
+			EnableMsgpackEncoding:  true,
 			Metrics:                sdPeer,
 		},
 	})

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/honeycombio/dynsampler-go v0.2.1
 	github.com/honeycombio/libhoney-go v1.12.4
 	github.com/jessevdk/go-flags v1.4.0
+	github.com/json-iterator/go v1.1.6
 	github.com/klauspost/compress v1.10.3
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.3.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,7 @@ github.com/honeycombio/libhoney-go v1.12.4/go.mod h1:tp2qtK0xMZyG/ZfykkebQESKFS7
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/json-iterator/go v1.1.6 h1:MrUvLMLTMxbqFJ9kzlvat/rYZqZnW3u4wkLzWTaFwKs=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
@@ -178,7 +179,9 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.3.3 h1:SzB1nHZ2Xi+17FP0zVQBHIZqvwRN9408fJO8h+eeNA8=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=

--- a/route/route.go
+++ b/route/route.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/klauspost/compress/zstd"
 	"github.com/tinylib/msgp/msgp"
 	"github.com/vmihailenco/msgpack/v4"
@@ -640,7 +641,7 @@ func unmarshal(r *http.Request, data io.Reader, v interface{}) error {
 			UseDecodeInterfaceLoose(true).
 			Decode(v)
 	case "application/json":
-		return json.NewDecoder(data).Decode(v)
+		return jsoniter.NewDecoder(data).Decode(v)
 	default:
 		return errors.New("Bad Content-Type")
 	}


### PR DESCRIPTION
Switch to msgpack for internal (peer to peer and upstream) communication.

Switch to jsoniter for batch event unmarshal, which is notably faster than stock json.

The perf win here is pretty clear, and this benchmark doesn't capture the gains from encoding upstream traffic with msgpack, since libhoney's Writer transmission always uses json.

```
benchmark                              old ns/op     new ns/op     delta
BenchmarkDistributedTraces/batch-8     25991         17567         -32.41%

benchmark                              old allocs     new allocs     delta
BenchmarkDistributedTraces/batch-8     296            226            -23.65%

benchmark                              old bytes     new bytes     delta
BenchmarkDistributedTraces/batch-8     23634         19938         -15.64%
```