### PR TITLE
send excess traces when reducing cache size

### DIFF
--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -27,7 +27,6 @@ type Cache interface {
 // order) so it is important to have a cache larger than trace throughput *
 // longest trace.
 type DefaultInMemCache struct {
-	Config  CacheConfig
 	Metrics metrics.Metrics
 	Logger  logger.Logger
 
@@ -39,32 +38,35 @@ type DefaultInMemCache struct {
 	insertPoint int
 }
 
-type CacheConfig struct {
-	CacheCapacity int
-}
-
 const DefaultInMemCacheCapacity = 10000
 
-func (d *DefaultInMemCache) Start() error {
-	d.Logger.Debug().Logf("Starting DefaultInMemCache")
-	defer func() { d.Logger.Debug().Logf("Finished starting DefaultInMemCache") }()
-	if d.Config.CacheCapacity == 0 {
-		d.Config.CacheCapacity = DefaultInMemCacheCapacity
-	}
-	d.cache = make(map[string]*types.Trace, d.Config.CacheCapacity)
-	d.insertionOrder = make([]*types.Trace, d.Config.CacheCapacity)
-
-	// register statistics sent by this module
+func NewInMemCache(
+	capacity int,
+	metrics metrics.Metrics,
+	logger logger.Logger,
+) *DefaultInMemCache {
+	logger.Debug().Logf("Starting DefaultInMemCache")
+	defer func() { logger.Debug().Logf("Finished starting DefaultInMemCache") }()
 
 	// buffer_overrun increments when the trace overwritten in the circular
 	// buffer has not yet been sent
-	d.Metrics.Register("collect_cache_buffer_overrun", "counter")
+	metrics.Register("collect_cache_buffer_overrun", "counter")
 
-	return nil
+	if capacity == 0 {
+		capacity = DefaultInMemCacheCapacity
+	}
+
+	return &DefaultInMemCache{
+		Metrics:        metrics,
+		Logger:         logger,
+		cache:          make(map[string]*types.Trace, capacity),
+		insertionOrder: make([]*types.Trace, capacity),
+	}
+
 }
 
 func (d *DefaultInMemCache) GetCacheSize() int {
-	return d.Config.CacheCapacity
+	return len(d.insertionOrder)
 }
 
 // Set adds the trace to the ring. If it is kicking out a trace from the ring
@@ -84,7 +86,7 @@ func (d *DefaultInMemCache) Set(trace *types.Trace) *types.Trace {
 	defer func() { d.insertPoint++ }()
 
 	// loop insert point when we get to the end of the ring
-	if d.insertPoint >= d.Config.CacheCapacity {
+	if d.insertPoint >= len(d.insertionOrder) {
 		d.insertPoint = 0
 	}
 

--- a/collect/cache/cache_test.go
+++ b/collect/cache/cache_test.go
@@ -15,12 +15,7 @@ import (
 func TestCacheSetGet(t *testing.T) {
 	s := &metrics.MockMetrics{}
 	s.Start()
-	c := &DefaultInMemCache{
-		Config:  CacheConfig{10},
-		Metrics: s,
-		Logger:  &logger.NullLogger{},
-	}
-	c.Start()
+	c := NewInMemCache(10, s, &logger.NullLogger{})
 
 	trace := &types.Trace{
 		TraceID: "abc123",
@@ -35,12 +30,7 @@ func TestCacheSetGet(t *testing.T) {
 func TestBufferOverrun(t *testing.T) {
 	s := &metrics.MockMetrics{}
 	s.Start()
-	c := &DefaultInMemCache{
-		Config:  CacheConfig{2},
-		Metrics: s,
-		Logger:  &logger.NullLogger{},
-	}
-	c.Start()
+	c := NewInMemCache(2, s, &logger.NullLogger{})
 
 	traces := []*types.Trace{
 		&types.Trace{TraceID: "abc123"},
@@ -58,12 +48,7 @@ func TestBufferOverrun(t *testing.T) {
 func TestTakeExpiredTraces(t *testing.T) {
 	s := &metrics.MockMetrics{}
 	s.Start()
-	c := &DefaultInMemCache{
-		Config:  CacheConfig{10},
-		Metrics: s,
-		Logger:  &logger.NullLogger{},
-	}
-	c.Start()
+	c := NewInMemCache(10, s, &logger.NullLogger{})
 
 	now := time.Now()
 	traces := []*types.Trace{

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -53,7 +53,7 @@ type InMemCollector struct {
 
 	// mutex must be held whenever non-channel internal fields are accessed.
 	// This exists to avoid data races in tests and startup/shutdown.
-	mutex sync.Mutex
+	mutex sync.RWMutex
 
 	cache           cache.Cache
 	datasetSamplers map[string]sample.Sampler
@@ -483,8 +483,8 @@ func (i *InMemCollector) Stop() error {
 
 // Convenience method for tests.
 func (i *InMemCollector) getFromCache(traceID string) *types.Trace {
-	i.mutex.Lock()
-	defer i.mutex.Unlock()
+	i.mutex.RLock()
+	defer i.mutex.RUnlock()
 
 	return i.cache.Get(traceID)
 }

--- a/collect/collect.go
+++ b/collect/collect.go
@@ -150,9 +150,10 @@ func (i *InMemCollector) reloadConfigs() {
 			}
 			c.Start()
 			// pull the old cache contents into the new cache
-			for i, trace := range existingCache.GetAll() {
-				if i > imcConfig.CacheCapacity {
-					break
+			for j, trace := range existingCache.GetAll() {
+				if j >= imcConfig.CacheCapacity {
+					i.send(trace)
+					continue
 				}
 				c.Set(trace)
 			}

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -339,7 +339,7 @@ func TestCacheSizeReload(t *testing.T) {
 	coll.AddSpan(&types.Span{TraceID: "2", Event: event})
 
 	expectedEvents := 1
-	wait := conf.SendTickerVal
+	wait := 2 * time.Millisecond
 	check := func() bool {
 		transmission.Mux.RLock()
 		defer transmission.Mux.RUnlock()
@@ -348,7 +348,9 @@ func TestCacheSizeReload(t *testing.T) {
 	}
 	assert.Eventually(t, check, 10*wait, wait, "expected one trace evicted and sent")
 
+	conf.Mux.Lock()
 	conf.GetInMemoryCollectorCacheCapacityVal.CacheCapacity = 2
+	conf.Mux.Unlock()
 	conf.ReloadConfig()
 
 	assert.Eventually(t, func() bool {
@@ -362,7 +364,9 @@ func TestCacheSizeReload(t *testing.T) {
 	time.Sleep(5 * conf.SendTickerVal)
 	assert.True(t, check(), "expected no more traces evicted and sent")
 
+	conf.Mux.Lock()
 	conf.GetInMemoryCollectorCacheCapacityVal.CacheCapacity = 1
+	conf.Mux.Unlock()
 	conf.ReloadConfig()
 
 	expectedEvents = 2

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -40,16 +40,7 @@ func TestAddRootSpan(t *testing.T) {
 		},
 	}
 
-	c := &cache.DefaultInMemCache{
-		Config: cache.CacheConfig{
-			CacheCapacity: 3,
-		},
-		Metrics: &metrics.NullMetrics{},
-		Logger:  &logger.NullLogger{},
-	}
-	err := c.Start()
-	assert.NoError(t, err, "in-mem cache should start")
-
+	c := cache.NewInMemCache(3, &metrics.NullMetrics{}, &logger.NullLogger{})
 	coll.cache = c
 	stc, err := lru.New(15)
 	assert.NoError(t, err, "lru cache should start")
@@ -123,14 +114,7 @@ func TestAddSpan(t *testing.T) {
 			Logger: &logger.NullLogger{},
 		},
 	}
-	c := &cache.DefaultInMemCache{
-		Config: cache.CacheConfig{
-			CacheCapacity: 3,
-		},
-		Metrics: &metrics.NullMetrics{},
-		Logger:  &logger.NullLogger{},
-	}
-	c.Start()
+	c := cache.NewInMemCache(3, &metrics.NullMetrics{}, &logger.NullLogger{})
 	coll.cache = c
 	stc, err := lru.New(15)
 	assert.NoError(t, err, "lru cache should start")
@@ -199,15 +183,7 @@ func TestDryRunMode(t *testing.T) {
 		Metrics:        &metrics.NullMetrics{},
 		SamplerFactory: samplerFactory,
 	}
-	c := &cache.DefaultInMemCache{
-		Config: cache.CacheConfig{
-			CacheCapacity: 3,
-		},
-		Metrics: &metrics.NullMetrics{},
-		Logger:  &logger.NullLogger{},
-	}
-	err := c.Start()
-	assert.NoError(t, err, "in-mem cache should start")
+	c := cache.NewInMemCache(3, &metrics.NullMetrics{}, &logger.NullLogger{})
 	coll.cache = c
 	stc, err := lru.New(15)
 	assert.NoError(t, err, "lru cache should start")
@@ -467,14 +443,7 @@ func TestMaxAlloc(t *testing.T) {
 			Logger: &logger.NullLogger{},
 		},
 	}
-	c := &cache.DefaultInMemCache{
-		Config: cache.CacheConfig{
-			CacheCapacity: 1000,
-		},
-		Metrics: &metrics.NullMetrics{},
-		Logger:  &logger.NullLogger{},
-	}
-	c.Start()
+	c := cache.NewInMemCache(1000, &metrics.NullMetrics{}, &logger.NullLogger{})
 	coll.cache = c
 	stc, err := lru.New(15)
 	assert.NoError(t, err, "lru cache should start")

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -354,8 +354,8 @@ func TestCacheSizeReload(t *testing.T) {
 	conf.ReloadConfig()
 
 	assert.Eventually(t, func() bool {
-		coll.mutex.Lock()
-		defer coll.mutex.Unlock()
+		coll.mutex.RLock()
+		defer coll.mutex.RUnlock()
 
 		return coll.cache.(*cache.DefaultInMemCache).GetCacheSize() == 2
 	}, 10*wait, wait, "cache size to change")

--- a/config/mock.go
+++ b/config/mock.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"sync"
 	"time"
 )
 
@@ -55,98 +56,196 @@ type MockConfig struct {
 	PeerManagementType            string
 	DebugServiceAddr              string
 	DryRun                        bool
+
+	Mux sync.RWMutex
 }
 
 func (m *MockConfig) ReloadConfig() {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	for _, callback := range m.Callbacks {
 		callback()
 	}
 }
 func (m *MockConfig) RegisterReloadCallback(callback func()) {
+	m.Mux.Lock()
 	m.Callbacks = append(m.Callbacks, callback)
+	m.Mux.Unlock()
 }
-func (m *MockConfig) GetAPIKeys() ([]string, error) { return m.GetAPIKeysVal, m.GetAPIKeysErr }
+func (m *MockConfig) GetAPIKeys() ([]string, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetAPIKeysVal, m.GetAPIKeysErr
+}
 func (m *MockConfig) GetCollectorType() (string, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.GetCollectorTypeVal, m.GetCollectorTypeErr
 }
 func (m *MockConfig) GetInMemCollectorCacheCapacity() (InMemoryCollectorCacheCapacity, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.GetInMemoryCollectorCacheCapacityVal, m.GetInMemoryCollectorCacheCapacityErr
 }
 func (m *MockConfig) GetHoneycombAPI() (string, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.GetHoneycombAPIVal, m.GetHoneycombAPIErr
 }
-func (m *MockConfig) GetListenAddr() (string, error) { return m.GetListenAddrVal, m.GetListenAddrErr }
+func (m *MockConfig) GetListenAddr() (string, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetListenAddrVal, m.GetListenAddrErr
+}
 func (m *MockConfig) GetPeerListenAddr() (string, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.GetPeerListenAddrVal, m.GetPeerListenAddrErr
 }
-func (m *MockConfig) GetLoggerType() (string, error) { return m.GetLoggerTypeVal, m.GetLoggerTypeErr }
+func (m *MockConfig) GetLoggerType() (string, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetLoggerTypeVal, m.GetLoggerTypeErr
+}
 func (m *MockConfig) GetHoneycombLoggerConfig() (HoneycombLoggerConfig, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.GetHoneycombLoggerConfigVal, m.GetHoneycombLoggerConfigErr
 }
 func (m *MockConfig) GetLoggingLevel() (string, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.GetLoggingLevelVal, m.GetLoggingLevelErr
 }
 func (m *MockConfig) GetOtherConfig(name string, iface interface{}) error {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	err := json.Unmarshal([]byte(m.GetOtherConfigVal), iface)
 	if err != nil {
 		return err
 	}
 	return m.GetOtherConfigErr
 }
-func (m *MockConfig) GetPeers() ([]string, error)   { return m.GetPeersVal, m.GetPeersErr }
-func (m *MockConfig) GetRedisHost() (string, error) { return m.GetRedisHostVal, m.GetRedisHostErr }
+func (m *MockConfig) GetPeers() ([]string, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetPeersVal, m.GetPeersErr
+}
+func (m *MockConfig) GetRedisHost() (string, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.GetRedisHostVal, m.GetRedisHostErr
+}
 func (m *MockConfig) GetMetricsType() (string, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.GetMetricsTypeVal, m.GetMetricsTypeErr
 }
 func (m *MockConfig) GetHoneycombMetricsConfig() (HoneycombMetricsConfig, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.GetHoneycombMetricsConfigVal, m.GetHoneycombMetricsConfigErr
 }
 func (m *MockConfig) GetPrometheusMetricsConfig() (PrometheusMetricsConfig, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.GetPrometheusMetricsConfigVal, m.GetPrometheusMetricsConfigErr
 }
 func (m *MockConfig) GetSendDelay() (time.Duration, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.GetSendDelayVal, m.GetSendDelayErr
 }
 func (m *MockConfig) GetTraceTimeout() (time.Duration, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.GetTraceTimeoutVal, m.GetTraceTimeoutErr
 }
 
 // TODO: allow per-dataset mock values
 func (m *MockConfig) GetSamplerConfigForDataset(dataset string) (interface{}, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.GetSamplerTypeVal, m.GetSamplerTypeErr
 }
 
 func (m *MockConfig) GetUpstreamBufferSize() int {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.GetUpstreamBufferSizeVal
 }
 func (m *MockConfig) GetPeerBufferSize() int {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.GetPeerBufferSizeVal
 }
 
 func (m *MockConfig) GetIdentifierInterfaceName() (string, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.IdentifierInterfaceName, nil
 }
 
 func (m *MockConfig) GetUseIPV6Identifier() (bool, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.UseIPV6Identifier, nil
 }
 
 func (m *MockConfig) GetRedisIdentifier() (string, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.RedisIdentifier, nil
 }
 
 func (m *MockConfig) GetSendTickerValue() time.Duration {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.SendTickerVal
 }
 
 func (m *MockConfig) GetPeerManagementType() (string, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.PeerManagementType, nil
 }
 
 func (m *MockConfig) GetDebugServiceAddr() (string, error) {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.DebugServiceAddr, nil
 }
 
 func (m *MockConfig) GetIsDryRun() bool {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
 	return m.DryRun
 }


### PR DESCRIPTION
Also fixes an off-by-one error in the cache building loop, and adds a mutex to mock config to avoid test races.