### PR TITLE
add mutex locking to fileConfig

### DIFF
--- a/config/file_config.go
+++ b/config/file_config.go
@@ -342,8 +342,8 @@ func (f *fileConfig) GetCollectorType() (string, error) {
 }
 
 func (f *fileConfig) GetSamplerConfigForDataset(dataset string) (interface{}, error) {
-	f.mux.Lock()
-	defer f.mux.Unlock()
+	f.mux.RLock()
+	defer f.mux.RUnlock()
 
 	key := fmt.Sprintf("%s.Sampler", dataset)
 	if ok := f.rules.IsSet(key); ok {


### PR DESCRIPTION
The trouble with config reloads is that it means we've got a background goroutine writing new config values - at the same time our code is occasionally reading these values. The real-world risk here is pretty low but in the spirit of cleaning up `go -race` it seems worth getting out of the way.