### PR TITLE
don't block batch endpoint on most queues

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -128,7 +128,9 @@ func newStartedApp(
 	metricsr := &metrics.MockMetrics{}
 	metricsr.Start()
 
-	collector := &collect.InMemCollector{}
+	collector := &collect.InMemCollector{
+		BlockOnAddSpan: true,
+	}
 
 	peerList, err := peers.GetPeers()
 	assert.NoError(t, err)

--- a/cmd/samproxy/main.go
+++ b/cmd/samproxy/main.go
@@ -143,7 +143,6 @@ func main() {
 			PendingWorkCapacity:  uint(c.GetPeerBufferSize()),
 			UserAgentAddition:    userAgentAddition,
 			Transport:            peerTransport,
-			BlockOnSend:          true,
 			// gzip compression is expensive, and peers are most likely close to each other
 			// so we can turn off gzip when forwarding to peers
 			DisableGzipCompression: true,

--- a/collect/collect_benchmark_test.go
+++ b/collect/collect_benchmark_test.go
@@ -47,6 +47,7 @@ func BenchmarkCollect(b *testing.B) {
 			Config: conf,
 			Logger: log,
 		},
+		BlockOnAddSpan:  true,
 		cache:           cache.NewInMemCache(3, metric, log),
 		incoming:        make(chan *types.Span, 500),
 		fromPeer:        make(chan *types.Span, 500),

--- a/route/route.go
+++ b/route/route.go
@@ -438,6 +438,10 @@ func (r *Router) batch(w http.ResponseWriter, req *http.Request) {
 				&BatchResponse{Status: http.StatusAccepted},
 			)
 			ev.APIHost = targetShard.GetAddress()
+
+			// Unfortunately this doesn't tell us if the event was actually
+			// enqueued; we need to watch the response channel to find out, at
+			// which point it's too late to tell the client.
 			r.PeerTransmission.EnqueueEvent(ev)
 			continue
 		}

--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -81,13 +81,13 @@ func (d *DefaultTransmission) reloadTransmissionBuilder() {
 }
 
 func (d *DefaultTransmission) EnqueueEvent(ev *types.Event) {
-	d.Logger.Debug().WithFields(map[string]interface{}{
-		"request_id": ev.Context.Value(types.RequestIDContextKey{}),
-		"api_host":   ev.APIHost,
-		"dataset":    ev.Dataset,
-		"type":       ev.Type,
-		"target":     ev.Target,
-	}).Logf("transmit sending event")
+	d.Logger.Debug().
+		WithField("request_id", ev.Context.Value(types.RequestIDContextKey{})).
+		WithString("api_host", ev.APIHost).
+		WithString("dataset", ev.Dataset).
+		WithString("type", ev.Type.String()).
+		WithString("target", ev.Target.String()).
+		Logf("transmit sending event")
 	libhEv := d.builder.NewEvent()
 	libhEv.APIHost = ev.APIHost
 	libhEv.WriteKey = ev.APIKey
@@ -108,14 +108,14 @@ func (d *DefaultTransmission) EnqueueEvent(ev *types.Event) {
 	err := libhEv.SendPresampled()
 	if err != nil {
 		d.Metrics.IncrementCounter(d.Name + counterEnqueueErrors)
-		d.Logger.Error().WithFields(map[string]interface{}{
-			"error":      err.Error(),
-			"request_id": ev.Context.Value(types.RequestIDContextKey{}),
-			"dataset":    ev.Dataset,
-			"api_host":   ev.APIHost,
-			"type":       ev.Type.String(),
-			"target":     ev.Target.String(),
-		}).Logf("failed to enqueue event")
+		d.Logger.Error().
+			WithString("error", err.Error()).
+			WithField("request_id", ev.Context.Value(types.RequestIDContextKey{})).
+			WithString("dataset", ev.Dataset).
+			WithString("api_host", ev.APIHost).
+			WithString("type", ev.Type.String()).
+			WithString("target", ev.Target.String()).
+			Logf("failed to enqueue event")
 	}
 }
 


### PR DESCRIPTION
The collector channel adds now return an error instead of blocking, and peer libhoney has been set non-blocking. Upstream libhoney is still blocking.

Also cleaned up a bit of logging code to slightly reduce allocations.