### PR TITLE
peers list should not be required in config

### DIFF
--- a/config/file_config.go
+++ b/config/file_config.go
@@ -70,7 +70,7 @@ type HoneycombMetricsConfig struct {
 
 type PeerManagementConfig struct {
 	Type                    string   `validate:"required,oneof= file redis"`
-	Peers                   []string `validate:"required,dive,url"`
+	Peers                   []string `validate:"dive,url"`
 	RedisHost               string
 	IdentifierInterfaceName string
 	UseIPV6Identifier       bool


### PR DESCRIPTION
Peers list is not required if file type is redis. https://github.com/honeycombio/samproxy/issues/147