### PR TITLE
consolidate event handling code

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -199,7 +199,7 @@ func newStartedApp(
 	return &a, g
 }
 
-func post(t *testing.T, req *http.Request) {
+func post(t testing.TB, req *http.Request) {
 	resp, err := httpClient.Do(req)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -348,11 +348,6 @@ func TestEventsEndpoint(t *testing.T) {
 			SampleRate: 10,
 			APIHost:    "http://api.honeycomb.io",
 			Timestamp:  now,
-			Metadata: map[string]string{
-				"type":     "unknown",
-				"api_host": "http://api.honeycomb.io",
-				"dataset":  "dataset",
-			},
 			Data: map[string]interface{}{
 				"trace.trace_id": "1",
 				"foo":            "bar",
@@ -387,11 +382,6 @@ func TestEventsEndpoint(t *testing.T) {
 			SampleRate: 10,
 			APIHost:    "http://api.honeycomb.io",
 			Timestamp:  now,
-			Metadata: map[string]string{
-				"type":     "span",
-				"api_host": "http://api.honeycomb.io",
-				"dataset":  "dataset",
-			},
 			Data: map[string]interface{}{
 				"trace.trace_id": "1",
 				"foo":            "bar",
@@ -472,13 +462,7 @@ func BenchmarkTraces(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			blob := `[` + string(spans[n%len(spans)]) + `]`
 			req.Body = ioutil.NopCloser(strings.NewReader(blob))
-			resp, err := httpClient.Do(req)
-			assert.NoError(b, err)
-			if resp != nil {
-				assert.Equal(b, http.StatusOK, resp.StatusCode)
-				io.Copy(ioutil.Discard, resp.Body)
-				resp.Body.Close()
-			}
+			post(b, req)
 		}
 		sender.waitForCount(b, b.N)
 	})
@@ -497,13 +481,7 @@ func BenchmarkTraces(b *testing.B) {
 			blob[len(blob)-1] = ']'
 			req.Body = ioutil.NopCloser(bytes.NewReader(blob))
 
-			resp, err := httpClient.Do(req)
-			assert.NoError(b, err)
-			if resp != nil {
-				assert.Equal(b, http.StatusOK, resp.StatusCode)
-				io.Copy(ioutil.Discard, resp.Body)
-				resp.Body.Close()
-			}
+			post(b, req)
 		}
 		sender.waitForCount(b, b.N)
 	})
@@ -588,13 +566,7 @@ func BenchmarkDistributedTraces(b *testing.B) {
 			blob := `[` + string(spans[n%len(spans)]) + `]`
 			req.Body = ioutil.NopCloser(strings.NewReader(blob))
 			req.URL.Host = addrs[n%len(addrs)]
-			resp, err := httpClient.Do(req)
-			assert.NoError(b, err)
-			if resp != nil {
-				assert.Equal(b, http.StatusOK, resp.StatusCode)
-				io.Copy(ioutil.Discard, resp.Body)
-				resp.Body.Close()
-			}
+			post(b, req)
 		}
 		sender.waitForCount(b, b.N)
 	})
@@ -614,13 +586,7 @@ func BenchmarkDistributedTraces(b *testing.B) {
 			req.Body = ioutil.NopCloser(bytes.NewReader(blob))
 			req.URL.Host = addrs[n%len(addrs)]
 
-			resp, err := httpClient.Do(req)
-			assert.NoError(b, err)
-			if resp != nil {
-				assert.Equal(b, http.StatusOK, resp.StatusCode)
-				io.Copy(ioutil.Discard, resp.Body)
-				resp.Body.Close()
-			}
+			post(b, req)
 		}
 		sender.waitForCount(b, b.N)
 	})

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/pelletier/go-toml v1.8.0 // indirect
-	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0
@@ -33,7 +32,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.5.1
-	github.com/tinylib/msgp v1.1.2
 	github.com/vmihailenco/msgpack/v4 v4.3.11
 	golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6 // indirect
 	golang.org/x/text v0.3.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,6 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.0 h1:Keo9qb7iRJs2voHvunFtuuYFsbWeOBh8/P9v/kVMFtw=
 github.com/pelletier/go-toml v1.8.0/go.mod h1:D6yutnOGMveHEPV7VQOuvI/gXY61bv+9bAOTRnLElKs=
-github.com/philhofer/fwd v1.0.0 h1:UbZqGr5Y38ApvM/V/jEljVxwocdweyH+vmYvRPBnbqQ=
-github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
@@ -258,8 +256,6 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/tinylib/msgp v1.1.2 h1:gWmO7n0Ys2RBEb7GPYB9Ujq8Mk5p2U08lRnmMcGy6BQ=
-github.com/tinylib/msgp v1.1.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/vmihailenco/msgpack/v4 v4.3.11 h1:Q47CePddpNGNhk4GCnAx9DDtASi2rasatE0cd26cZoE=
 github.com/vmihailenco/msgpack/v4 v4.3.11/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=

--- a/route/route.go
+++ b/route/route.go
@@ -202,8 +202,13 @@ func (r *Router) version(w http.ResponseWriter, req *http.Request) {
 func (r *Router) event(w http.ResponseWriter, req *http.Request) {
 	defer req.Body.Close()
 
-	// get out request ID for logging
-	reqBod, _ := ioutil.ReadAll(req.Body)
+	bodyReader, err := r.getMaybeCompressedBody(req)
+	if err != nil {
+		r.handlerReturnWithError(w, ErrPostBody, err)
+		return
+	}
+
+	reqBod, _ := ioutil.ReadAll(bodyReader)
 	ev, err := r.requestToEvent(req, reqBod)
 	if err != nil {
 		r.handlerReturnWithError(w, ErrReqToEvent, err)

--- a/route/route.go
+++ b/route/route.go
@@ -18,7 +18,6 @@ import (
 	"github.com/gorilla/mux"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/klauspost/compress/zstd"
-	"github.com/tinylib/msgp/msgp"
 	"github.com/vmihailenco/msgpack/v4"
 
 	"github.com/honeycombio/samproxy/collect"
@@ -525,16 +524,6 @@ func makeDecoders(num int) (chan *zstd.Decoder, error) {
 func unmarshal(r *http.Request, data io.Reader, v interface{}) error {
 	switch r.Header.Get("Content-Type") {
 	case "application/x-msgpack", "application/msgpack":
-		// First try to decode with the fast but fussy msgp. If that fails,
-		// defer to the much more friendly msgpack.
-		if decodable, ok := v.(msgp.Decodable); ok {
-			err := msgp.Decode(data, decodable)
-
-			if err == nil {
-				return nil
-			}
-		}
-
 		return msgpack.NewDecoder(data).
 			UseDecodeInterfaceLoose(true).
 			Decode(v)

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -95,16 +95,22 @@ func TestDecompression(t *testing.T) {
 
 func unmarshalRequest(w *httptest.ResponseRecorder, content string, body io.Reader) {
 	http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var e eventWithTraceID
-		err := unmarshal(r, r.Body, &e)
-
+		var data map[string]interface{}
+		err := unmarshal(r, r.Body, &data)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte(err.Error()))
 			return
 		}
 
-		w.Write([]byte(e.TraceID))
+		var traceID string
+		if trID, ok := data["trace.trace_id"]; ok {
+			traceID = trID.(string)
+		} else if trID, ok := data["traceId"]; ok {
+			traceID = trID.(string)
+		}
+
+		w.Write([]byte(traceID))
 	}).ServeHTTP(w, &http.Request{
 		Body: ioutil.NopCloser(body),
 		Header: http.Header{

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -136,7 +136,7 @@ func unmarshalBatchRequest(w *httptest.ResponseRecorder, content string, body io
 func TestUnmarshal(t *testing.T) {
 	var w *httptest.ResponseRecorder
 	var body io.Reader
-	now := time.Now()
+	now := time.Now().UTC()
 
 	w = httptest.NewRecorder()
 	body = bytes.NewBufferString("")

--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -86,7 +86,6 @@ func (d *DefaultTransmission) EnqueueEvent(ev *types.Event) {
 		WithString("api_host", ev.APIHost).
 		WithString("dataset", ev.Dataset).
 		WithString("type", ev.Type.String()).
-		WithString("target", ev.Target.String()).
 		Logf("transmit sending event")
 	libhEv := d.builder.NewEvent()
 	libhEv.APIHost = ev.APIHost
@@ -96,7 +95,6 @@ func (d *DefaultTransmission) EnqueueEvent(ev *types.Event) {
 	libhEv.Timestamp = ev.Timestamp
 	libhEv.Metadata = map[string]string{
 		"type":     ev.Type.String(),
-		"target":   ev.Target.String(),
 		"api_host": ev.APIHost,
 		"dataset":  ev.Dataset,
 	}
@@ -114,7 +112,6 @@ func (d *DefaultTransmission) EnqueueEvent(ev *types.Event) {
 			WithString("dataset", ev.Dataset).
 			WithString("api_host", ev.APIHost).
 			WithString("type", ev.Type.String()).
-			WithString("target", ev.Target.String()).
 			Logf("failed to enqueue event")
 	}
 }

--- a/transmit/transmit.go
+++ b/transmit/transmit.go
@@ -85,7 +85,6 @@ func (d *DefaultTransmission) EnqueueEvent(ev *types.Event) {
 		WithField("request_id", ev.Context.Value(types.RequestIDContextKey{})).
 		WithString("api_host", ev.APIHost).
 		WithString("dataset", ev.Dataset).
-		WithString("type", ev.Type.String()).
 		Logf("transmit sending event")
 	libhEv := d.builder.NewEvent()
 	libhEv.APIHost = ev.APIHost
@@ -93,11 +92,6 @@ func (d *DefaultTransmission) EnqueueEvent(ev *types.Event) {
 	libhEv.Dataset = ev.Dataset
 	libhEv.SampleRate = ev.SampleRate
 	libhEv.Timestamp = ev.Timestamp
-	libhEv.Metadata = map[string]string{
-		"type":     ev.Type.String(),
-		"api_host": ev.APIHost,
-		"dataset":  ev.Dataset,
-	}
 
 	for k, v := range ev.Data {
 		libhEv.AddField(k, v)
@@ -111,7 +105,6 @@ func (d *DefaultTransmission) EnqueueEvent(ev *types.Event) {
 			WithField("request_id", ev.Context.Value(types.RequestIDContextKey{})).
 			WithString("dataset", ev.Dataset).
 			WithString("api_host", ev.APIHost).
-			WithString("type", ev.Type.String()).
 			Logf("failed to enqueue event")
 	}
 }

--- a/types/event.go
+++ b/types/event.go
@@ -16,30 +16,9 @@ const (
 // used to put a request ID into the request context for logging
 type RequestIDContextKey struct{}
 
-type EventType int
-
-const (
-	EventTypeUnknown EventType = iota
-	EventTypeSpan
-	EventTypeEvent
-)
-
-func (et EventType) String() string {
-	switch et {
-	case EventTypeUnknown:
-		return "unknown"
-	case EventTypeSpan:
-		return "span"
-	case EventTypeEvent:
-		return "event"
-	}
-	return "unknown_event_type"
-}
-
 // event is not part of a trace - it's an event that showed up with no trace ID
 type Event struct {
 	Context    context.Context
-	Type       EventType
 	APIHost    string
 	APIKey     string
 	Dataset    string

--- a/types/event.go
+++ b/types/event.go
@@ -36,31 +36,10 @@ func (et EventType) String() string {
 	return "unknown_event_type"
 }
 
-type TargetType int
-
-const (
-	TargetUnknown TargetType = iota
-	TargetPeer
-	TargetUpstream
-)
-
-func (tt TargetType) String() string {
-	switch tt {
-	case TargetUnknown:
-		return "unknown"
-	case TargetPeer:
-		return "peer"
-	case TargetUpstream:
-		return "upstream"
-	}
-	return "unknown_target_type"
-}
-
 // event is not part of a trace - it's an event that showed up with no trace ID
 type Event struct {
 	Context    context.Context
 	Type       EventType
-	Target     TargetType
 	APIHost    string
 	APIKey     string
 	Dataset    string


### PR DESCRIPTION
Share the important bits between the batch and event handlers. Add an integration test for the event endpoint. Add testing of meta fields. Remove unused event metadata. Clean up some test code. Remove dead code.