### PR TITLE
add cache utilization and root span metrics

### DIFF
--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -51,6 +51,7 @@ func NewInMemCache(
 	// buffer_overrun increments when the trace overwritten in the circular
 	// buffer has not yet been sent
 	metrics.Register("collect_cache_buffer_overrun", "counter")
+	metrics.Register("collect_cache_capacity", "gauge")
 	metrics.Register("collect_cache_entries", "histogram")
 
 	if capacity == 0 {
@@ -128,6 +129,7 @@ func (d *DefaultInMemCache) GetAll() []*types.Trace {
 }
 
 func (d *DefaultInMemCache) TakeExpiredTraces(now time.Time) []*types.Trace {
+	d.Metrics.Gauge("collect_cache_capacity", float64(len(d.insertionOrder)))
 	d.Metrics.Histogram("collect_cache_entries", float64(len(d.cache)))
 
 	var res []*types.Trace

--- a/collect/cache/cache.go
+++ b/collect/cache/cache.go
@@ -51,6 +51,7 @@ func NewInMemCache(
 	// buffer_overrun increments when the trace overwritten in the circular
 	// buffer has not yet been sent
 	metrics.Register("collect_cache_buffer_overrun", "counter")
+	metrics.Register("collect_cache_entries", "histogram")
 
 	if capacity == 0 {
 		capacity = DefaultInMemCacheCapacity
@@ -127,8 +128,9 @@ func (d *DefaultInMemCache) GetAll() []*types.Trace {
 }
 
 func (d *DefaultInMemCache) TakeExpiredTraces(now time.Time) []*types.Trace {
-	var res []*types.Trace
+	d.Metrics.Histogram("collect_cache_entries", float64(len(d.cache)))
 
+	var res []*types.Trace
 	for i, t := range d.insertionOrder {
 		if t != nil && now.After(t.SendBy) {
 			res = append(res, t)

--- a/types/event.go
+++ b/types/event.go
@@ -91,6 +91,8 @@ type Trace struct {
 	// Used to calculate how long traces spend sitting in Samproxy
 	StartTime time.Time
 
+	HasRootSpan bool
+
 	// spans is the list of spans in this trace
 	spans []*Span
 }


### PR DESCRIPTION
Adds a histogram for active cache entries, and a gauge for capacity (it won't change much, if ever). Also adds counters for traces sent with and without root spans, to help monitor later or otherwise orphaned spans, which can fill up the trace cache.