### PR TITLE
Always update latest docker tag on main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,15 @@ workflows:
             tags:
               only: /.*/
       - docker/publish:
+          tag: latest
+          extra_build_args: --build-arg BUILD_ID=${CIRCLE_SHA1:0:7}
+          image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME
+          requires:
+            - build
+          filters:
+            branches:
+              only: main
+      - docker/publish:
           tag: latest,${CIRCLE_TAG:1}
           extra_build_args: --build-arg BUILD_ID=${CIRCLE_TAG:1}
           image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME


### PR DESCRIPTION
There was a request that we always publish latest on main branch to docker hub as the latest tag