### PR TITLE
Make response consistent with Honeycomb API

### DIFF
--- a/route/route.go
+++ b/route/route.go
@@ -188,7 +188,7 @@ func (r *Router) Stop() error {
 
 func (r *Router) alive(w http.ResponseWriter, req *http.Request) {
 	r.iopLogger.Debug().Logf("answered /x/alive check")
-	w.Write([]byte(`{"source":"samproxy","alive":true}`))
+	w.Write([]byte(`{"source":"samproxy","alive":"yes"}`))
 }
 
 func (r *Router) panic(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
The alive check for the honeycomb API uses a string value "yes" to respond to its health check.

https://api.honeycomb.io/x/alive

Update to match