### PR TITLE
Fix rules bug

### DIFF
--- a/config/file_config.go
+++ b/config/file_config.go
@@ -29,6 +29,10 @@ type RulesBasedSamplerCondition struct {
 	Value    interface{}
 }
 
+func (r *RulesBasedSamplerCondition) String() string {
+	return fmt.Sprintf("%+v", *r)
+}
+
 type RulesBasedSamplerRule struct {
 	Name       string
 	SampleRate int
@@ -36,8 +40,16 @@ type RulesBasedSamplerRule struct {
 	Condition  []*RulesBasedSamplerCondition
 }
 
+func (r *RulesBasedSamplerRule) String() string {
+	return fmt.Sprintf("%+v", *r)
+}
+
 type RulesBasedSamplerConfig struct {
 	Rule []*RulesBasedSamplerRule
+}
+
+func (r *RulesBasedSamplerConfig) String() string {
+	return fmt.Sprintf("%+v", *r)
 }
 
 type configContents struct {

--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -264,7 +264,7 @@ func TestRules(t *testing.T) {
 			Rules: &config.RulesBasedSamplerConfig{
 				Rule: []*config.RulesBasedSamplerRule{
 					{
-						Name:       "another test",
+						Name:       "test multiple rules must all be matched",
 						SampleRate: 4,
 						Condition: []*config.RulesBasedSamplerCondition{
 							{
@@ -298,6 +298,7 @@ func TestRules(t *testing.T) {
 				},
 			},
 			ExpectedKeep: true,
+			// the trace does not match all the rules so we expect the default sample rate
 			ExpectedRate: 1,
 		},
 	}

--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -260,6 +260,46 @@ func TestRules(t *testing.T) {
 			ExpectedKeep: false,
 			ExpectedRate: 0,
 		},
+		{
+			Rules: &config.RulesBasedSamplerConfig{
+				Rule: []*config.RulesBasedSamplerRule{
+					{
+						Name:       "another test",
+						SampleRate: 4,
+						Condition: []*config.RulesBasedSamplerCondition{
+							{
+								Field:    "first",
+								Operator: "=",
+								Value:    int64(1),
+							},
+							{
+								Field:    "second",
+								Operator: "=",
+								Value:    int64(2),
+							},
+						},
+					},
+				},
+			},
+			Spans: []*types.Span{
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"first": int64(1),
+						},
+					},
+				},
+				{
+					Event: types.Event{
+						Data: map[string]interface{}{
+							"first": int64(1),
+						},
+					},
+				},
+			},
+			ExpectedKeep: true,
+			ExpectedRate: 1,
+		},
 	}
 
 	for _, d := range data {

--- a/sample/rules_test.go
+++ b/sample/rules_test.go
@@ -281,7 +281,7 @@ func TestRules(t *testing.T) {
 
 		// we can only test when we don't expect to keep the trace
 		if !d.ExpectedKeep {
-			assert.Equal(t, d.ExpectedKeep, keep)
+			assert.Equal(t, d.ExpectedKeep, keep, d.Rules)
 		}
 	}
 }


### PR DESCRIPTION
There was a bug where we checked the matched length inside the condition loop. This moves that check outside of the condition loop and ensures that we stop looking at spans once a condition has been matched