### PR TITLE
Add customisable dry run field name

### DIFF
--- a/collect/collect.go
+++ b/collect/collect.go
@@ -373,8 +373,9 @@ func (i *InMemCollector) processSpan(sp *types.Span) {
 // sending the span immediately or dropping it.
 func (i *InMemCollector) dealWithSentTrace(keep bool, sampleRate uint, sp *types.Span) {
 	if i.Config.GetIsDryRun() {
+		field := i.Config.GetDryRunFieldName()
 		// if dry run mode is enabled, we keep all traces and mark the spans with the sampling decision
-		sp.Data["samproxy_kept"] = keep
+		sp.Data[field] = keep
 		if !keep {
 			i.Logger.Debug().WithField("trace_id", sp.TraceID).Logf("Sending span that would have been dropped, but dry run mode is enabled")
 			i.Transmission.EnqueueSpan(sp)
@@ -463,7 +464,8 @@ func (i *InMemCollector) send(trace *types.Trace) {
 			sp.SampleRate = 1
 		}
 		if i.Config.GetIsDryRun() {
-			sp.Data["samproxy_kept"] = shouldSend
+			field := i.Config.GetDryRunFieldName()
+			sp.Data[field] = shouldSend
 		}
 		// if spans are already sampled, take that in to account when computing
 		// the final rate

--- a/collect/collect_test.go
+++ b/collect/collect_test.go
@@ -164,14 +164,16 @@ func TestAddSpan(t *testing.T) {
 func TestDryRunMode(t *testing.T) {
 	transmission := &transmit.MockTransmission{}
 	transmission.Start()
+	field := "test_kept"
 	conf := &config.MockConfig{
 		GetSendDelayVal:    0,
 		GetTraceTimeoutVal: 60 * time.Second,
 		GetSamplerTypeVal: &config.DeterministicSamplerConfig{
 			SampleRate: 10,
 		},
-		SendTickerVal: 2 * time.Millisecond,
-		DryRun:        true,
+		SendTickerVal:   2 * time.Millisecond,
+		DryRun:          true,
+		DryRunFieldName: field,
 	}
 	samplerFactory := &sample.SamplerFactory{
 		Config: conf,
@@ -225,7 +227,7 @@ func TestDryRunMode(t *testing.T) {
 	assert.Nil(t, coll.getFromCache(traceID1), "after sending the span, it should be removed from the cache")
 	transmission.Mux.RLock()
 	assert.Equal(t, 1, len(transmission.Events), "adding a root span should send the span")
-	assert.Equal(t, keepTraceID1, transmission.Events[0].Data["samproxy_kept"], "field should match sampling decision for its trace ID")
+	assert.Equal(t, keepTraceID1, transmission.Events[0].Data[field], "field should match sampling decision for its trace ID")
 	transmission.Mux.RUnlock()
 
 	// add a non-root span, create the trace in the cache
@@ -254,8 +256,8 @@ func TestDryRunMode(t *testing.T) {
 	transmission.Mux.RLock()
 	assert.Equal(t, 3, len(transmission.Events), "adding another root span should send the span")
 	// both spans should be marked with the sampling decision
-	assert.Equal(t, keepTraceID2, transmission.Events[1].Data["samproxy_kept"], "field should match sampling decision for its trace ID")
-	assert.Equal(t, keepTraceID2, transmission.Events[2].Data["samproxy_kept"], "field should match sampling decision for its trace ID")
+	assert.Equal(t, keepTraceID2, transmission.Events[1].Data[field], "field should match sampling decision for its trace ID")
+	assert.Equal(t, keepTraceID2, transmission.Events[2].Data[field], "field should match sampling decision for its trace ID")
 	transmission.Mux.RUnlock()
 
 	span = &types.Span{
@@ -273,7 +275,7 @@ func TestDryRunMode(t *testing.T) {
 	assert.Nil(t, coll.getFromCache(traceID3), "after sending the span, it should be removed from the cache")
 	transmission.Mux.RLock()
 	assert.Equal(t, 4, len(transmission.Events), "adding a root span should send the span")
-	assert.Equal(t, keepTraceID3, transmission.Events[3].Data["samproxy_kept"], "field should match sampling decision for its trace ID")
+	assert.Equal(t, keepTraceID3, transmission.Events[3].Data[field], "field should match sampling decision for its trace ID")
 	transmission.Mux.RUnlock()
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -107,4 +107,6 @@ type Config interface {
 	GetDebugServiceAddr() (string, error)
 
 	GetIsDryRun() bool
+
+	GetDryRunFieldName() string
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -162,6 +162,10 @@ func TestReadDefaults(t *testing.T) {
 		t.Error("received", d, "expected", false)
 	}
 
+	if d := c.GetDryRunFieldName(); d != "refinery_kept" {
+		t.Error("received", d, "expected", "refinery_kept")
+	}
+
 	type imcConfig struct {
 		CacheCapacity int
 	}

--- a/config/file_config.go
+++ b/config/file_config.go
@@ -69,6 +69,7 @@ type configContents struct {
 	PeerBufferSize     int           `validate:"required"`
 	DebugServiceAddr   string
 	DryRun             bool
+	DryRunFieldName    string
 	PeerManagement     PeerManagementConfig           `validate:"required"`
 	InMemCollector     InMemoryCollectorCacheCapacity `validate:"required"`
 }
@@ -131,6 +132,7 @@ func NewConfig(config, rules string, errorCallback func(error)) (Config, error) 
 	c.SetDefault("UpstreamBufferSize", libhoney.DefaultPendingWorkCapacity)
 	c.SetDefault("PeerBufferSize", libhoney.DefaultPendingWorkCapacity)
 	c.SetDefault("DryRun", false)
+	c.SetDefault("DryRunFieldName", "refinery_kept")
 	c.SetDefault("MaxAlloc", uint64(0))
 
 	c.SetConfigFile(config)
@@ -642,4 +644,11 @@ func (f *fileConfig) GetIsDryRun() bool {
 	defer f.mux.RUnlock()
 
 	return f.conf.DryRun
+}
+
+func (f *fileConfig) GetDryRunFieldName() string {
+	f.mux.RLock()
+	defer f.mux.RUnlock()
+
+	return f.conf.DryRunFieldName
 }

--- a/config/mock.go
+++ b/config/mock.go
@@ -56,6 +56,7 @@ type MockConfig struct {
 	PeerManagementType            string
 	DebugServiceAddr              string
 	DryRun                        bool
+	DryRunFieldName               string
 
 	Mux sync.RWMutex
 }
@@ -248,4 +249,11 @@ func (m *MockConfig) GetIsDryRun() bool {
 	defer m.Mux.RUnlock()
 
 	return m.DryRun
+}
+
+func (m *MockConfig) GetDryRunFieldName() string {
+	m.Mux.RLock()
+	defer m.Mux.RUnlock()
+
+	return m.DryRunFieldName
 }

--- a/rules.toml
+++ b/rules.toml
@@ -6,7 +6,7 @@
 # and sends all traces regardless
 # DryRun = false
 
-# DryRunFieldName - the key to add to use to add to event data when using DryRun mode above
+# DryRunFieldName - the key to add to use to add to event data when using DryRun mode above, defaults to refinery_kept
 # DryRunFieldName = refinery_kept
 
 # DeterministicSampler is a section of the config for manipulating the

--- a/rules.toml
+++ b/rules.toml
@@ -6,6 +6,9 @@
 # and sends all traces regardless
 # DryRun = false
 
+# DryRunFieldName - the key to add to use to add to event data when using DryRun mode above
+# DryRunFieldName = refinery_kept
+
 # DeterministicSampler is a section of the config for manipulating the
 # Deterministic Sampler implementation. This is the simplest sampling algorithm
 # - it is a static sample rate, choosing traces randomly to either keep or send


### PR DESCRIPTION
Allows customizable dry run field name and updates the default to reference refinery and not samproxy